### PR TITLE
Add model training docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,6 +67,13 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "Training",
+                "pages": [
+                  "training/index",
+                  "training/torch"
+                ]
               }
             ]
           },

--- a/docs/training/index.mdx
+++ b/docs/training/index.mdx
@@ -1,0 +1,143 @@
+---
+title: "Loading Data for Model Training"
+sidebarTitle: "Data loading and shuffles"
+description: "Introduction to loading data, shuffling, and creating permutations for model training in LanceDB."
+---
+
+LanceDB makes an excellent data backend for training machine learning models. This section will describe the
+`Permutation` API in LanceDB that's designed to facilitate the
+process of training a model and explain how to use LanceDB as a data backend for training.
+
+## Data loading
+
+Most model training frameworks iterate through data in batches and feed this data into the model. This process is
+often referred to as **data loading**. The simplest way to load data into a model is to iterate a LanceDB table in
+a loop and feed the data into the model.
+
+<CodeGroup>
+```py Python icon=Python 
+import lancedb
+
+db = lancedb.connect("file://some/db/path")
+table = db.open_table("some_table")
+
+for batch in table:
+    print(batch.to_pydict())
+```
+</CodeGroup>
+
+In practice, this is too simplistic for effective training. We may not want to load all the data, or we may want
+to load the data in a different order, or we may need to apply some sort of processing to the data before training.
+To achieve this, we will often want to create a `Permutation` of the table.
+
+## Selecting rows
+
+When training a model, we might not want to load all of the data. For example, we might filter out columns that
+are not needed for training. We might also divide the data into training and validation sets. Or we could divide
+the data into multiple sets for cross-validation.
+
+Whenever we create a permutation of the table, we have to first decide which rows we want to include (and in what
+order). This is stored in a **permutation table** which marks out the row ids that make up our data. Other decisions,
+such as which columns to include, and what transformations to apply, can be defined at read time and don't require
+a separate permutation table.
+
+<Note>
+Permutation tables are tables, just like any other table in LanceDB. By default, they are
+stored in memory but they can be persisted to storage as well. This is useful when you want to share a permutation
+table across processes or nodes.
+</Note>
+
+## Selecting all rows
+
+To select all rows, we can use the `Permutation.identity` method. This gives us a `Permutation` without requiring
+us to create a separate permutation table. This allows us to refine our columns and apply transformations and can
+be useful when the data loader itself is responsible for handling sampling and shuffling.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation
+
+# We can create an identity permutation without needing any separate permutation table.
+permutation = Permutation.identity(table)
+
+# This allows us to refine our columns and apply transformations
+permutation = permutation.select_columns(["id", "prompt"])
+```
+</CodeGroup>
+
+## Filtering rows
+
+If we only want to select a subset of rows, then we can use a filter. This will require us to create a permutation
+table which identifies which rows we want to include.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation, permutation_builder
+
+# We can create a permutation table which identifies which rows we want to include.
+permutation_tbl = permutation_builder(table).filter("category = 'cat'").execute()
+
+# We can then use this permutation table to create a Permutation object
+permutation = Permutation.from_tables(table, permutation_tbl)
+```
+</CodeGroup>
+
+## Creating splits
+
+LanceDB also provides several different methods for creating splits. These allow us to divide our dataset into
+smaller non-overlapping sets. The split can then be specified when creating the `Permutation` object to view
+only a subset of the data.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation, permutation_builder
+
+# Here we create two splits, one for training and one for validation.  By default, splits have no
+# name and are accessed by index.
+permutation_tbl = permutation_builder(table).split_random(ratios=[0.95, 0.05]).execute()
+
+# Let's create a permutation object which views only the training data.
+permutation = Permutation.from_tables(table, permutation_tbl, split=0)
+
+# Splits can also be given names.  The names can then be used later to access the split instead of
+# requiring us to know the index.
+permutation_tbl = permutation_builder(table).split_random(ratios=[0.95, 0.05], split_names=["train", "test"]).execute()
+permutation = Permutation.from_tables(table, permutation_tbl, split="train")
+```
+</CodeGroup>
+
+## Shuffling rows
+
+By default, permutations will access the data in the order the data is stored in the table. This can cause our
+model to learn artifacts specific to the order of the data. This is one of many ways we can "overfit" our model
+to our data. To avoid this, we typically want to shuffle the data before training. Model training frameworks
+(like PyTorch) will often provide a way to shuffle the data. If you are not using one of these frameworks, or if
+you want to shuffle the data with LanceDB, you can shuffle the rows when you create a permutation table.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation, permutation_builder
+
+# We can shuffle the rows when we create the permutation table.
+permutation_tbl = permutation_builder(table).shuffle().execute()
+
+# We can then use this permutation table to create a Permutation object, this will now
+# access the data in a random order.
+permutation = Permutation.from_tables(table, permutation_tbl)
+```
+</CodeGroup>
+
+## Selecting columns
+
+By default, permutations will return all columns in the table. If you only need a subset of the columns, you can
+significantly reduce your I/O requirements by selecting only the columns you need. This can be done on the
+permutation object itself, and does not require us to create a separate permutation table.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation
+
+# We can select only the columns we need.
+permutation = Permutation.identity(table).select_columns(["id", "prompt"])
+```
+</CodeGroup>

--- a/docs/training/torch.mdx
+++ b/docs/training/torch.mdx
@@ -1,0 +1,54 @@
+---
+title: "PyTorch Integration"
+sidebar_title: "PyTorch integration"
+description: Learn how to use LanceDB with PyTorch for training and inference.
+---
+
+LanceDB provides a seamless integration with PyTorch for training and inference. This allows you to use LanceDB as a backend for your PyTorch models, and to use PyTorch for training and inference. You can use LanceDB to store your data, and PyTorch to train your models.
+
+## Quickstart
+
+The `Table` class in LanceDB implements a contract for a PyTorch
+[Dataset](https://docs.pytorch.org/docs/stable/data.html#torch.utils.data.Dataset).
+ This means you can simply use a LanceDB table in a PyTorch dataloader directly.
+
+<CodeGroup>
+```py Python icon=Python 
+import lancedb
+import torch
+import pyarrow as pa
+
+mem_db = lancedb.connect("memory://")
+table = mem_db.create_table("test_table", pa.table({"a": range(1000)}))
+
+# Any LanceDB table can be used as a PyTorch Dataset
+dataloader = torch.utils.data.DataLoader(
+    table, batch_size=1024, shuffle=True
+)
+
+for batch in dataloader:
+    print(batch)
+```
+</CodeGroup>
+
+Although the `Table` class in LanceDB implements the `torch.utils.data.Dataset` interface, you'll most likely find that using
+a table [Permutation](/training/) is more efficient for training.
+
+## Selecting columns
+
+By default, the `Table` class will return all columns in the table when used as input to PyTorch. If you only need
+a subset of columns, you can significantly reduce your I/O requirements by selecting only the columns you need.
+
+<CodeGroup>
+```py Python icon=Python 
+from lancedb.permutation import Permutation
+
+permutation = Permutation.identity(table).select_columns(["id", "prompt"])
+dataloader = torch.utils.data.DataLoader(
+    permutation, batch_size=1024, shuffle=True
+)
+
+for batch in dataloader:
+    print(batch.schema)
+```
+</CodeGroup>


### PR DESCRIPTION
Adds model training docs that describes the permutation API in LanceDB.

Will need to be reorganized into the "User Guides" group by @erik-wang-lancedb (update `docs.json` accordingly).