### PR TITLE
Remove venv activation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,20 @@
-SHELL := /bin/bash
-
 # Paths
 SCRIPT := scripts/mdx_snippets_gen.py
 
-# Helper to ensure we run within the local virtualenv
-ACTIVATE_VENV := . .venv/bin/activate
-
+# uv run automatically handles virtualenv, so no activation needed
 .PHONY: py ts rs snippets
 
 # Generate Python MDX snippets
 py:
-	@$(ACTIVATE_VENV); uv run $(SCRIPT) -s tests/py
+	@uv run $(SCRIPT) -s tests/py
 
 # Generate TypeScript MDX snippets
 ts:
-	@$(ACTIVATE_VENV); uv run $(SCRIPT) -s tests/ts
+	@uv run $(SCRIPT) -s tests/ts
+
 # Generate Rust MDX snippets
 rs:
-	@$(ACTIVATE_VENV); uv run $(SCRIPT) -s tests/rs
+	@uv run $(SCRIPT) -s tests/rs
 
 # Convenience: generate all snippets
 snippets: py ts rs


### PR DESCRIPTION
uv should automatically handle venv, thus removing the manual activation of venv should make makefile compatible across unix and Windows devices (I think?)

@prrao87 works for me on Windows, when you get a chance can test on Linux and merge if it works?