### PR TITLE
Revamp contexts doc

### DIFF
--- a/docs/geneva/jobs/contexts.mdx
+++ b/docs/geneva/jobs/contexts.mdx
@@ -154,17 +154,23 @@ manifest = (
         .pip(["lancedb", "numpy"])
         .py_modules(["my_module"])
     ).build()
-)
 
 db.define_manifest(manifest_name, manifest)
 ```
 </CodeGroup>
 
-This manifest contains a couple ways to get files and resources to the Ray workers:
-- local environment: Everything in your local environment, including your local working directory and python `site_packages`, will be zipped and sent to workers.
-  - you can see these zip files by setting `.local_zip_output_dir(path)` in the builder, or set `.delete_local_zips(True)` if you don't care
-  - you can set `skip_site_packages=True` if you don't want to upload your entire local `site_packages`. This is useful, for example, for the `pyarrow` or many-libraries cases we mentioned earlier. In that case, you will probably need `pip` and `py_modules`:
-- `pip` and `py_modules`: packages that you want to be installed, but are not installed locally. These are passed in to Ray's [RuntimeEnv](https://docs.ray.io/en/latest/ray-core/api/doc/ray.runtime_env.RuntimeEnv.html#ray-runtime-env-runtimeenv), which has more details about how they are included. In short, `pip` is a list of packages that you want it to install from pip, and `py_modules` is a list of local or remote zip files that Ray unzips and adds to workers' PYTHONPATHs.
+What's in a manifest and how can you define it? (methods are all on `GenevaManifestBuilder`)
+
+|Contents|How you can define it|
+|---|---|
+|Local python packages|Will be uploaded automatically, unless you set `.skip_site_packages(True)`.|
+|Local working directory (or workspace root, if in a python repo)|Will be uploaded automatically.|
+|Python packages to be installed with `pip`|Use `.pip(packages: list[str])` or `.add_pip(package: str)`. See [Ray's RuntimeEnv docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.runtime_env.RuntimeEnv.html) for details.|
+|Local python packages outside of `site_packages`|Use `.py_modules(modules: list[str])` or `.add_py_module(module: str)`. See [Ray's RuntimeEnv docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.runtime_env.RuntimeEnv.html) for details.|
+|Container image for head node|Use `.head_image(head_image: str)` or `default_head_image()` to use the default. Note that, if the image is also defined in the GenevaCluster, the image set here in the Manifest will take priority.|
+|Container image for worker nodes|Use `.worker_image(worker_image: str)` or `default_worker_image()` to use the default for the current platform. As with the head image, this takes priority over any images set in the Cluster.|
+
+If you want to see exactly what is being uploaded to the cluster, set `.delete_local_zips(False)` and `.local_zip_output_dir(path)` then examine the zip files in `path`.
 
 ## Putting it all together: Execution Contexts
 


### PR DESCRIPTION
Made a bunch of changes here to introduce Clusters, then Manifests, then execution contexts, hopefully in a more straightforward way. I wanted to make it clear that you have 3 choices for cluster, and 2 choices for how to upload your environment; I think that might not have been clear to the FE team.

See it here: https://lancedb-bcbb4faf-dantasse-contexts-again.mintlify.app/geneva/jobs/contexts