### PR TITLE
Document StorageOptionsProvider for dynamic cloud credentials

### DIFF
--- a/docs/snippets/storage.mdx
+++ b/docs/snippets/storage.mdx
@@ -12,6 +12,8 @@ export const PyStorageConnectTimeout = "db = lancedb.connect(\n    \"s3://bucket
 
 export const PyStorageGcsServiceAccount = "db = lancedb.connect(\n    \"gs://my-bucket/my-database\",\n    storage_options={\n        \"service_account\": \"path/to/service-account.json\",\n    },\n)\n";
 
+export const PyStorageOptionsProvider = "from __future__ import annotations\n\nfrom typing import Dict\n\nimport lancedb\nfrom lancedb.io import StorageOptionsProvider\n\nclass MyProvider(StorageOptionsProvider):\n    def fetch_storage_options(self) -> Dict[str, str]:\n        # Return the same keys you would normally pass via `storage_options`.\n        # Example: fetch credentials from your secret manager / STS / metadata service.\n        return {\n            \"aws_access_key_id\": \"...\",\n            \"aws_secret_access_key\": \"...\",\n            \"aws_session_token\": \"...\",\n            \"region\": \"us-east-1\",\n        }\n\ndb = lancedb.connect(\"s3://bucket/path\")\n\n# Table creation\n_ = db.create_table(\n    \"my_table\",\n    [{\"id\": 1, \"vector\": [0.0, 1.0]}],\n    storage_options_provider=MyProvider(),\n)\n\n# Table open\n_ = db.open_table(\n    \"my_table\",\n    storage_options_provider=MyProvider(),\n)\n";
+
 export const PyStorageS3Ddb = "db = lancedb.connect(\n    \"s3+ddb://bucket/path?ddbTableName=my-dynamodb-table\",\n)\n";
 
 export const PyStorageS3Express = "db = lancedb.connect(\n    \"s3://my-bucket--use1-az4--x-s3/path\",\n    storage_options={\n        \"region\": \"us-east-1\",\n        \"s3_express\": \"true\",\n    },\n)\n";

--- a/docs/storage/configuration.mdx
+++ b/docs/storage/configuration.mdx
@@ -11,6 +11,7 @@ import {
     PyStorageConnectS3,
     PyStorageConnectTimeout,
     PyStorageGcsServiceAccount,
+    PyStorageOptionsProvider,
     PyStorageS3Ddb,
     PyStorageS3Express,
     PyStorageS3Minio,
@@ -102,6 +103,26 @@ If you need the option to apply only to a specific table:
 | `proxy_url` | Proxy URL to route requests through. |
 | `proxy_ca_certificate` | PEM-formatted CA certificate for proxy connections. |
 | `proxy_excludes` | Comma-separated hosts that bypass the proxy (domains or CIDR). |
+
+### Dynamic / expiring credentials (StorageOptionsProvider)
+
+In production, cloud credentials are often **temporary** (for example, AWS STS session tokens, Kubernetes IRSA, or workload identity). In these cases, setting static environment variables or passing a fixed `storage_options` dictionary may stop working once the credentials expire.
+
+LanceDB supports dynamic credential refresh via a **storage options provider**:
+
+- Implement a `StorageOptionsProvider` with a `fetch_storage_options()` method.
+- Pass it to `create_table(..., storage_options_provider=...)` or `open_table(..., storage_options_provider=...)`.
+- LanceDB will call your provider to obtain up-to-date `storage_options` when it needs to access the underlying object store.
+
+<Note>
+This pattern is intended for **refreshing credentials**. Use `storage_options` for static configuration (region, endpoint, timeouts, etc.) and a provider for values that may change (access keys, session tokens, etc.).
+</Note>
+
+<CodeGroup>
+  <CodeBlock language="Python" title="StorageOptionsProvider example" icon="python">
+    {PyStorageOptionsProvider}
+  </CodeBlock>
+</CodeGroup>
 
 ## AWS S3
 

--- a/tests/py/test_storage.py
+++ b/tests/py/test_storage.py
@@ -120,6 +120,44 @@ def test_storage_snippets(fake_connect):
     # --8<-- [end:storage_tigris_connect]
 
     assert len(fake_connect) == 10
+
+
+def test_storage_options_provider_snippet():
+    """Snippet for StorageOptionsProvider documentation."""
+    # --8<-- [start:storage_options_provider]
+    from __future__ import annotations
+
+    from typing import Dict
+
+    import lancedb
+    from lancedb.io import StorageOptionsProvider
+
+    class MyProvider(StorageOptionsProvider):
+        def fetch_storage_options(self) -> Dict[str, str]:
+            # Return the same keys you would normally pass via `storage_options`.
+            # Example: fetch credentials from your secret manager / STS / metadata service.
+            return {
+                "aws_access_key_id": "...",
+                "aws_secret_access_key": "...",
+                "aws_session_token": "...",
+                "region": "us-east-1",
+            }
+
+    db = lancedb.connect("s3://bucket/path")
+
+    # Table creation
+    _ = db.create_table(
+        "my_table",
+        [{"id": 1, "vector": [0.0, 1.0]}],
+        storage_options_provider=MyProvider(),
+    )
+
+    # Table open
+    _ = db.open_table(
+        "my_table",
+        storage_options_provider=MyProvider(),
+    )
+    # --8<-- [end:storage_options_provider]
     assert all(
         conn.uri.startswith(("s3://", "gs://", "az://", "s3+ddb://"))
         for conn in fake_connect


### PR DESCRIPTION
Add StorageOptionsProvider example to test_storage.py and import as snippet in configuration.mdx for dynamic credential refresh.

---
*Created by [Oqoqo](https://oqoqo.ai)*