### PR TITLE
Document LanceDB Cloud region availability (us-east-1 only)

### DIFF
--- a/docs/cloud/index.mdx
+++ b/docs/cloud/index.mdx
@@ -15,6 +15,12 @@ and enterprise-grade reliability.
 
 ![What is LanceDB?](/static/assets/images/overview/multimodal.png)
 
+## Region Availability
+
+LanceDB Cloud is currently available in **AWS us-east-1** (N. Virginia). All data is stored and processed in this region.
+
+For deployments in other regions (EU, Asia-Pacific, etc.) or other cloud providers, [LanceDB Enterprise](/enterprise/) offers flexible deployment options including bring-your-own-cloud (BYOC) with support for AWS, GCP, and Azure in your preferred region.
+
 ## Key Features
 
 LanceDB Cloud provides the same underlying fast vector database and search engine that powers the OSS version,


### PR DESCRIPTION
Add Region Availability section to Cloud overview clarifying that LanceDB Cloud is currently available in AWS us-east-1 only, with a pointer to LanceDB Enterprise for BYOC options in other regions.

---
*Created by [Oqoqo](https://oqoqo.ai)*