### PR TITLE
Re-organize and rename Geneva sections

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -152,7 +152,7 @@
               "geneva/index",
               "geneva/overview/index",
               {
-                "group": "UDFs",
+                "group": "User Defined Functions (UDFs)",
                 "pages": [
                   "geneva/udfs/index",
                   "geneva/udfs/blobs",
@@ -161,21 +161,26 @@
                 ]
               },
               {
-                "group": "Job execution",
+                "group": "Jobs",
                 "pages": [
                   "geneva/jobs/lifecycle",
                   "geneva/jobs/backfilling",
                   "geneva/jobs/conflicts",
-                  "geneva/jobs/startup",
                   "geneva/jobs/materialized-views",
-                  "geneva/jobs/contexts",
-                  "geneva/deployment/dependency-verification",
-                  "geneva/jobs/console",
                   "geneva/jobs/performance"
                 ]
               },
               {
-                "group": "Deployment & scaling",
+                "group": "Operations",
+                "pages": [
+                  "geneva/jobs/contexts",
+                  "geneva/deployment/dependency-verification",
+                  "geneva/jobs/startup",
+                  "geneva/jobs/console"
+                ]
+              },
+              {
+                "group": "Deployment",
                 "pages": [
                   "geneva/deployment/index",
                   "geneva/deployment/helm",

--- a/docs/geneva/jobs/conflicts.mdx
+++ b/docs/geneva/jobs/conflicts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Backfill Conflicts
-sidebarTitle: Conflicts
+sidebarTitle: Backfill Conflicts
 description: Learn how Geneva handles conflicts during backfill operations and what to do when they occur.
 icon: code-merge
 ---


### PR DESCRIPTION
## Summary
- Reorganize Geneva sidebar: split "Job execution" into "Jobs" and "Operations" groups
- Rename "UDFs" to "User Defined Functions (UDFs)" and "Deployment & scaling" to "Deployment"
- Move `dependency-verification` into the Operations group below `contexts`

## Test plan
- [ ] Verify sidebar navigation renders correctly on the docs site
- [ ] Confirm all linked pages resolve without 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)