### PR TITLE
Fix spelling and grammar errors across docs

### DIFF
--- a/docs/embedding/quickstart.mdx
+++ b/docs/embedding/quickstart.mdx
@@ -26,7 +26,7 @@ from lancedb.embeddings import get_registry
 - `lancedb`: The main database connection and operations
 - `LanceModel`: Pydantic model for defining table schemas
 - `Vector`: Field type for storing vector embeddings
-- `get_registry()`: Access to the embedding function registry. It has all the supported as well custom embedding functions registered by the user
+- `get_registry()`: Access to the embedding function registry. It has all the supported as well as custom embedding functions registered by the user
 
 ## Step 2: Connect to LanceDB
 

--- a/docs/enterprise/index.mdx
+++ b/docs/enterprise/index.mdx
@@ -35,7 +35,7 @@ ensures complete data sovereignty and high performance at scale.
 ### 2. Best performance for petabyte scale
 
 LanceDB OSS is built on the highly-efficient Lance format and offers extensive features out of the box. Our
-Enterprise solution amplifies these benefits by means of a custom-build distributed system. 
+Enterprise solution amplifies these benefits by means of a custom-built distributed system. 
 
 | Benefit | Description |
 |:--------|:------------|

--- a/docs/geneva/jobs/startup.mdx
+++ b/docs/geneva/jobs/startup.mdx
@@ -68,4 +68,4 @@ Here are some steps you can take to pre-warming worker nodes and pods so that ex
 
 **Make a warmup call:**  Making an initial request to ray will load the pod and zips content to the worker node so that subsequent startups will be fast.  
 
-**Prevent nodes from auto-scaling down:** During cluster creation, you can specifiy `idle_timeout_seconds` option  -- this is the amount of time before an node needs to be idle before it is considered for de-provisioning.
+**Prevent nodes from auto-scaling down:** During cluster creation, you can specify `idle_timeout_seconds` option  -- this is the amount of time before a node needs to be idle before it is considered for de-provisioning.

--- a/docs/geneva/udfs/udfs.mdx
+++ b/docs/geneva/udfs/udfs.mdx
@@ -83,9 +83,9 @@ def sum_vals(vals: np.ndarray | None) -> int | None:
 
 You can also define a **stateful** UDF that retains its state across calls.
 
-This can be used to share code and **parameterize your UDFs**.  In the example below, the model being used is a parameter that can be specified at UDF registration time.  It can also be used to paramterize input column names of `pa.RecordBatch` batch UDFS.
+This can be used to share code and **parameterize your UDFs**.  In the example below, the model being used is a parameter that can be specified at UDF registration time.  It can also be used to parameterize input column names of `pa.RecordBatch` batch UDFS.
 
-This also can be used to **optimize expensive initialization** that may require heavy resource on the distributed workers.  For example, this can be used to load an model to the GPU once for all records sent to a worker instead of once per record or per batch of records.
+This also can be used to **optimize expensive initialization** that may require heavy resources on the distributed workers.  For example, this can be used to load a model to the GPU once for all records sent to a worker instead of once per record or per batch of records.
 
 A stateful UDF is a `Callable` class, with `__call__()` method.  The call method can be a scalar function or a batched function.
 
@@ -260,11 +260,11 @@ Let's say you backfilled data with your UDF then you noticed that your data has 
 2. Most values are correct but some values are incorrect due to a failure in UDF execution.
 3. Values calculated correctly and you want to perform a second pass to fixup some of the values.
 
-In scenario 1, you'll most likely want to replaced the UDF with a new version and recalulate all the values.  You should perform a `alter_table` and then `backfill`.
+In scenario 1, you'll most likely want to replace the UDF with a new version and recalculate all the values.  You should perform a `alter_table` and then `backfill`.
 
 In scenario 2, you'll most likely want to re-execute `backfill` to fill in the values.  If the error is in your code (certain cases not handled), you can modify the UDF, and perform an `alter_table`, and then `backfill` with some filters.
 
-In scenario 3, you have a few options. A) You could `alter` your UDF and include the fixup operations in the UDF.  You'd `alter_table` and then `backfill` recalculating all the values.  B) You could have a chain of computed columns -- create a new column, calculate the "fixed" up values and have your application use the new column or a combination of the original column.  This is similar to A but does not recalulate A and can incur more storage.   C) You could `update` the values in the the column with the fixed up values.  This may be expedient but also sacrifices reproducability.
+In scenario 3, you have a few options. A) You could `alter` your UDF and include the fixup operations in the UDF.  You'd `alter_table` and then `backfill` recalculating all the values.  B) You could have a chain of computed columns -- create a new column, calculate the "fixed" up values and have your application use the new column or a combination of the original column.  This is similar to A but does not recalculate A and can incur more storage.   C) You could `update` the values in the column with the fixed up values.  This may be expedient but also sacrifices reproducibility.
 
 The next section shows you how to change your column definition by `alter`ing the UDF.
 

--- a/docs/indexing/index.mdx
+++ b/docs/indexing/index.mdx
@@ -140,7 +140,7 @@ HNSW builds on k-ANN in two main ways:
 
 This recursive structure can be thought of as separating into layers:
 
-* At the bottom-most layer, an k-ANN graph on the whole dataset is present.
+* At the bottom-most layer, a k-ANN graph on the whole dataset is present.
 * At the second layer, a k-ANN graph on a fraction of the dataset (e.g. 10%) is present.
 * At the Lth layer, a k-ANN graph is present. It is over a (constant) fraction (e.g. 10%) of the vectors/vertices present in the L-1th layer.
 

--- a/docs/integrations/ai/genkit.mdx
+++ b/docs/integrations/ai/genkit.mdx
@@ -41,14 +41,14 @@ This'll add LanceDB as a retriever and indexer to the genkit instance. You can s
 Let's see the raw retrieval results
 
 <img width="1710" alt="Screenshot 2025-05-11 at 7 21 05 PM" src="https://github.com/user-attachments/assets/b8d356ed-8421-4790-8fc0-d6af563b9657" />
-On running this query, you'll 5 results fetched from the lancedb table, where each result looks something like this:
+On running this query, you'll get 5 results fetched from the lancedb table, where each result looks something like this:
 <img width="1417" alt="Screenshot 2025-05-11 at 7 21 18 PM" src="https://github.com/user-attachments/assets/77429525-36e2-4da6-a694-e58c1cf9eb83" />
 
 
 
 ## Creating a custom RAG flow
 
-Now that we've seen how you can use LanceDB for in a genkit pipeline, let's refine the flow and create a RAG. A RAG flow will consist of an index and a retreiver with its outputs postprocessed an fed into an LLM for final response
+Now that we've seen how you can use LanceDB in a Genkit pipeline, let's refine the flow and create a RAG. A RAG flow will consist of an index and a retriever with its outputs postprocessed and fed into an LLM for final response
 
 ### Creating custom indexer flows
 You can also create custom indexer flows, utilizing more options and features provided by LanceDB.
@@ -68,6 +68,6 @@ You can also create custom retriever flows, utilizing more options and features 
 <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
   {TsFrameworksGenkitCustomRetriever}
 </CodeBlock>
-Now using our retrieval flow, we can ask question about the ingsted PDF
+Now using our retrieval flow, we can ask a question about the ingested PDF
 <img width="1306" alt="Screenshot 2025-05-11 at 7 18 45 PM" src="https://github.com/user-attachments/assets/86c66b13-7c12-4d5f-9d81-ae36bfb1c346" />
 

--- a/docs/integrations/ai/langchain.mdx
+++ b/docs/integrations/ai/langchain.mdx
@@ -97,7 +97,7 @@ This method creates a scalar(for non-vector cols) or a vector index on a table.
 |`index_cache_size`|`Optional[int]` |Size of the index cache.|`None`|
 |`name`|`Optional[str]` |Name of the table to create index on.|`None`|
 
-For index creation make sure your table has enough data in it. An ANN index is ususally not needed for datasets ~100K vectors. For large-scale (>1M) or higher dimension vectors, it is beneficial to create an ANN index.
+For index creation make sure your table has enough data in it. An ANN index is usually not needed for datasets ~100K vectors. For large-scale (>1M) or higher dimension vectors, it is beneficial to create an ANN index.
 
 <CodeBlock filename="Python" language="Python" icon="python">
   {PyFrameworksLangchainCreateIndex}
@@ -209,7 +209,7 @@ Similarly, `max_marginal_relevance_search_by_vector()` function returns docs mos
 
 ##### add_images()
 
-This method ddds images by automatically creating their embeddings and adds them to the vectorstore.
+This method adds images by automatically creating their embeddings and adds them to the vectorstore.
 
 | Name       | Type                          | Purpose                        | Default |
 |------------|-------------------------------|--------------------------------|---------|

--- a/docs/integrations/ai/synthetic-data-kit.mdx
+++ b/docs/integrations/ai/synthetic-data-kit.mdx
@@ -7,7 +7,7 @@ description: "Use Meta Llama's Synthetic Data Kit with LanceDB to generate high-
 
 
 
-[Sythetic Data Kit](https://github.com/meta-llama/synthetic-data-kit) is a tool from Meta LLAMA that helps you generate high-quality synthetic datasets for fine-tuning large language models (LLMs). It simplifies the process of preparing data for fine-tuning by providing a command-line interface (CLI) with a modular four-command flow.
+[Synthetic Data Kit](https://github.com/meta-llama/synthetic-data-kit) is a tool from Meta LLAMA that helps you generate high-quality synthetic datasets for fine-tuning large language models (LLMs). It simplifies the process of preparing data for fine-tuning by providing a command-line interface (CLI) with a modular four-command flow.
 
 One of the key features of the `synthetic-data-kit` is its use of the Lance format for storing and ingesting datasets. This allows for efficient storage and retrieval of data, which is crucial when working with large datasets.
 

--- a/docs/integrations/data/dlt.mdx
+++ b/docs/integrations/data/dlt.mdx
@@ -40,9 +40,9 @@ In this example, we will be fetching movie information from the [Open Movie Data
 
 3. **Specify necessary credentials and/or embedding model details:**  
     
-    In order to fetch data from the OMDb API, you will need to pass a valid API key into your pipeline. Depending on whether you're using LanceDB OSS or LanceDB Enterprise, you also may need to provide the necessary credentials to connect to the LanceDB instance. These can be pasted inside `.dlt/sercrets.toml`. 
+    In order to fetch data from the OMDb API, you will need to pass a valid API key into your pipeline. Depending on whether you're using LanceDB OSS or LanceDB Enterprise, you also may need to provide the necessary credentials to connect to the LanceDB instance. These can be pasted inside `.dlt/secrets.toml`. 
 
-    dlt's LanceDB integration also allows you to automatically embed the data during ingestion. Depending on the embedding model chosen, you may need to paste the necessary credentials inside `.dlt/sercrets.toml`:
+    dlt's LanceDB integration also allows you to automatically embed the data during ingestion. Depending on the embedding model chosen, you may need to paste the necessary credentials inside `.dlt/secrets.toml`:
     ```toml
     [sources.rest_api]
     api_key = "api_key" # Enter the API key for the OMDb API

--- a/docs/integrations/embedding/gemini.mdx
+++ b/docs/integrations/embedding/gemini.mdx
@@ -11,10 +11,10 @@ The Gemini Embedding Model API supports various task types:
 | Task Type               | Description                                                                                                                                                |
 |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | "`retrieval_query`"     | Specifies the given text is a query in a search/retrieval setting.                                                                                         |
-| "`retrieval_document`"  | Specifies the given text is a document in a search/retrieval setting. Using this task type requires a title but is automatically proided by Embeddings API |
+| "`retrieval_document`"  | Specifies the given text is a document in a search/retrieval setting. Using this task type requires a title but is automatically provided by Embeddings API |
 | "`semantic_similarity`" | Specifies the given text will be used for Semantic Textual Similarity (STS).                                                                               |
 | "`classification`"      | Specifies that the embeddings will be used for classification.                                                                                             |
-| "`clusering`"           | Specifies that the embeddings will be used for clustering.                                                                                                 |
+| "`clustering`"           | Specifies that the embeddings will be used for clustering.                                                                                                 |
 
 
 Usage Example:

--- a/docs/integrations/embedding/ibm.mdx
+++ b/docs/integrations/embedding/ibm.mdx
@@ -30,7 +30,7 @@ The following parameters can be passed to the `create` method:
 
 ## Usage Example
 
-First, the watsonx.ai library is an optional dependency, so must be installed seperately:
+First, the watsonx.ai library is an optional dependency, so must be installed separately:
 
 ```
 pip install ibm-watsonx-ai

--- a/docs/integrations/embedding/openai.mdx
+++ b/docs/integrations/embedding/openai.mdx
@@ -11,7 +11,7 @@ LanceDB registers the OpenAI embeddings function in the registry by default, as 
 |---|---|---|---|
 | `name` | `str` | `"text-embedding-ada-002"` | The name of the model. |
 | `dim` | `int` |  Model default   | For OpenAI's newer text-embedding-3 model, we can specify a dimensionality that is smaller than the 1536 size. This feature supports it |
-| `use_azure` | bool | `False` | Set true to use Azure OpenAPI SDK |
+| `use_azure` | bool | `False` | Set true to use Azure OpenAI SDK |
 
 <CodeGroup>
   <CodeBlock filename="Python" language="Python" icon="python">

--- a/docs/integrations/embedding/openclip.mdx
+++ b/docs/integrations/embedding/openclip.mdx
@@ -19,7 +19,7 @@ We support CLIP model embeddings using the open source alternative, [open-clip](
 | `batch_size` | `int` | `64` | The number of images to process in a batch. |
 | `normalize` | `bool` | `True` | Whether to normalize the input images before feeding them to the model. |
 
-This embedding function supports ingesting images as both bytes and urls. You can query them using both test and other images.
+This embedding function supports ingesting images as both bytes and urls. You can query them using both text and other images.
 
 <Info>
 LanceDB supports ingesting images directly from accessible links.

--- a/docs/integrations/reranking/cross_encoder.mdx
+++ b/docs/integrations/reranking/cross_encoder.mdx
@@ -23,7 +23,7 @@ Accepted Arguments
 ----------------
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
-| `model_name` | `str` | `""cross-encoder/ms-marco-TinyBERT-L-6"` | The name of the reranker model to use.|
+| `model_name` | `str` | `"cross-encoder/ms-marco-TinyBERT-L-6"` | The name of the reranker model to use.|
 | `column` | `str` | `"text"` | The name of the column to use as input to the cross encoder model. |
 | `device` | `str` | `None` | The device to use for the cross encoder model. If None, will use "cuda" if available, otherwise "cpu". |
 | `return_score` | `str` | `"relevance"` | Options are "relevance" or "all". The type of score to return. If "relevance", will return only the `_relevance_score. If "all" is supported, will return relevance score along with the vector and/or fts scores depending on query type. |

--- a/docs/reranking/index.mdx
+++ b/docs/reranking/index.mdx
@@ -64,6 +64,6 @@ reranked = reranker.rerank_multivector([res1, res2, res3],  deduplicate=True)
 
 ## Creating Custom Rerankers
 
-LanceDB also you to create custom rerankers by extending the base `Reranker` class. The custom reranker
+LanceDB also allows you to create custom rerankers by extending the base `Reranker` class. The custom reranker
 should implement the `rerank` method that takes a list of search results and returns a reranked list of
 search results. This is covered in more detail in the [creating custom rerankers](/reranking/custom-reranker/) section.

--- a/docs/tables/update.mdx
+++ b/docs/tables/update.mdx
@@ -99,7 +99,7 @@ Or, connect to LanceDB Enterprise:
 
 ## Create the example table
 
-We'll start by creating a simple table of a table with `id`, `name`, and `login_count` columns. All examples below use the same table.
+We'll start by creating a simple table with `id`, `name`, and `login_count` columns. All examples below use the same table.
 <CodeGroup>
     <CodeBlock filename="Python" language="Python" icon="python">
     {UpdateExampleTableSetup}


### PR DESCRIPTION
## Summary
- Fix 31 spelling and grammar errors found during a full scan of all ~152 documentation files
- Corrections span 16 files across integrations, geneva, embedding, enterprise, indexing, search, and tables docs
- Includes misspellings (ingsted, clusering, seperately, sercrets, proided, etc.), missing words, wrong articles (an→a before consonants), doubled words ("the the"), and incorrect verb forms

## Test plan
- [x] Verify docs site renders correctly with `mintlify dev` or equivalent
- [x] Spot-check a few of the changed files to confirm formatting is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)