### PR TITLE
docs(geneva): mark bulk load columns as Beta

### DIFF
--- a/docs/geneva/jobs/bulk-load-columns.mdx
+++ b/docs/geneva/jobs/bulk-load-columns.mdx
@@ -5,7 +5,7 @@ description: Load or update column data from external sources (Parquet, Lance, I
 icon: columns-3
 ---
 
-<Badge>Introduced in Geneva 0.13.0</Badge>
+<Badge>Beta — introduced in Geneva 0.13.0</Badge>
 
 ## Overview
 


### PR DESCRIPTION
Trivial change to mark bulk load as beta in the same style as other geneva features 