### PR TITLE
Document indexing constraints, FTS tokenizer knobs, and HNSW-quantized variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ boost-example
 .vscode
 node_modules
 tests/rs/target
+
+# Generated docs-audit workflow state
+workflows/docs-audit/artifacts/**
+!workflows/docs-audit/artifacts/
+workflows/docs-audit/state/**
+!workflows/docs-audit/state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,6 @@ This is a documentation site for [LanceDB](https://docs.lancedb.com).
 - Best practices for linting, formatting and code complexity for each respective language apply.
 - Write idiomatic code as far as possible
 
-## Running Python code
-
-When running Python code, we have to cater to users of both pip and uv.
-
-- Use 4 spaces to represent a tab (do not use tab characters)
-- Always attempt to first run *any* Python code via the local virtual environment
-  - Look for a local virtual environment (typically in `.venv` or `venv`)
-  - Activate the environment, so that you can run multiple code exampes in the same environment
-- Avoid using `uv run` directly, as you have issues running it in your sandbox
-- Only fall back to the system `python3` to run code if the above steps don't work
-
 ## Generate snippets
 
 - Generate the required code snippets using the provided Makefile: `make snippets`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,6 @@ This is a documentation site for [LanceDB](https://docs.lancedb.com).
 - Best practices for linting, formatting and code complexity for each respective language apply.
 - Write idiomatic code as far as possible
 
-## Running Python code
+## Generate snippets
 
-When running Python code, we have to cater to users of both pip and uv.
-
-- Use 4 spaces to represent a tab (do not use tab characters)
-- Always attempt to first run *any* Python code via the local virtual environment
-  - Look for a local virtual environment (typically in `.venv` or `venv`)
-  - Activate the environment, so that you can run multiple code exampes in the same environment
-- Avoid using `uv run` directly, as you have issues running it in your sandbox
-- Only fall back to the system `python3` to run code if the above steps don't work
+- Generate the required code snippets using the provided Makefile: `make snippets`

--- a/docs/indexing/fts-index.mdx
+++ b/docs/indexing/fts-index.mdx
@@ -62,6 +62,10 @@ The `create_fts_index` method is not available on `AsyncTable`. Use `create_inde
 | `stem` | bool | `True` | Apply stemming (`running` → `run`) |
 | `remove_stop_words` | bool | `True` | Drop common stop words |
 | `ascii_folding` | bool | `True` | Normalize accented characters |
+| `custom_stop_words` | list[str] | `None` | Extra stop words to drop in addition to the language defaults. Requires `remove_stop_words=True`. |
+| `min_ngram_length` | int | `3` | Minimum n-gram length. Applies only when `base_tokenizer="ngram"`. |
+| `max_ngram_length` | int | `3` | Maximum n-gram length. Applies only when `base_tokenizer="ngram"`. |
+| `prefix_only` | bool | `False` | Index only prefix n-grams rather than all substrings. Applies only when `base_tokenizer="ngram"`. |
 
 <Note title="Key parameters">
 - `max_token_length` can filter out base64 blobs or long URLs.

--- a/docs/indexing/quantization.mdx
+++ b/docs/indexing/quantization.mdx
@@ -16,8 +16,10 @@ Use quantization when:
 LanceDB currently exposes multiple quantized vector index types, including:
 - `IVF_PQ` -- Inverted File index with Product Quantization (default). See the [vector indexing guide](/indexing/vector-index) for `IVF_PQ` examples.
 - `IVF_RQ` -- Inverted File index with **RaBitQ** quantization (binary, 1 bit per dimension). Requires vector dimensions divisible by `8`. See [below](#rabitq-quantization) for details.
+- `IVF_HNSW_SQ` -- IVF partitions with an **HNSW graph per partition** plus **Scalar Quantization**. Strong recall/latency/size trade-off for most workloads.
+- `IVF_HNSW_PQ` -- IVF partitions with an **HNSW graph per partition** plus **Product Quantization**. Prefer when PQ-level compression matters and you still want HNSW-style in-partition search.
 
-`IVF_PQ` is the default indexing option in LanceDB and works well in many cases. However, in cases where more drastic compression is needed, RaBitQ is also a reasonable option.
+Two axes are being combined here: whether partitions are searched flatly or via an HNSW graph (`IVF_*` vs. `IVF_HNSW_*`), and which quantizer compresses the vectors (`PQ`, `RQ`, or `SQ`). `IVF_PQ` is the default and works well in many cases. For more drastic compression, RaBitQ (`IVF_RQ`) is a reasonable option. For higher recall at low latency, the HNSW-backed variants are usually the right pick. The ["Choose the Right Index"](/indexing/vector-index#choose-the-right-index) table on the vector indexing page is the canonical decision tool.
 
 ## RaBitQ quantization
 

--- a/docs/indexing/vector-index.mdx
+++ b/docs/indexing/vector-index.mdx
@@ -208,6 +208,10 @@ Compare ANN results against a flat-scan ground truth to compute recall@k. This i
 Flat search is $O(n)$ — reserve `bypass_vector_index()` for sampled recall measurements or small tables, not production queries.
 </Warning>
 
+<Note title="Multivector distance constraint">
+Multivector indexing currently requires `distance_type="cosine"` — `l2` is rejected at index-creation time. That restriction is why `bypass_vector_index()` is the escape hatch for non-cosine queries on a multivector column: the metric you want at query time cannot be served by the index, so you fall back to a flat scan. See [Multivector Search](/search/multivector-search) for the full rules.
+</Note>
+
 ## Example: Construct an HNSW Index
 
 ### Index Configuration
@@ -247,6 +251,13 @@ Binary vectors are useful for hash-based retrieval, fingerprinting, or any scena
 - Index Type: `IVF_FLAT` is used for indexing binary vectors
 - `metric`: the `hamming` distance is used for similarity search
 - The dimension of binary vectors must be a multiple of 8. For example, a 128-dimensional vector is stored as a uint8 array of size 16.
+
+<Warning>
+**`IVF_FLAT` + `hamming` is the only supported path for binary vectors.**
+
+- `hamming` distance is only valid on packed binary (uint8) data; it is rejected on float vector columns.
+- Quantized index types (`IVF_PQ`, `IVF_RQ`, `IVF_SQ`, `IVF_HNSW_PQ`, `IVF_HNSW_SQ`) do not accept binary inputs — their `distance_type` is restricted to `l2`, `cosine`, or `dot`.
+</Warning>
 
 ### 1. Create Table and Schema
 

--- a/docs/search/full-text-search.mdx
+++ b/docs/search/full-text-search.mdx
@@ -156,6 +156,7 @@ The tokenizer is customizable, you can specify how the tokenizer splits the text
 - `stem`: true
 - `remove_stop_words`: true
 - `ascii_folding`: true
+- `custom_stop_words`: `None` — pass a `list[str]` to drop additional words beyond the language defaults. Requires `remove_stop_words=True`.
 
 For example, for language with accents, you can specify the tokenizer to use `ascii_folding` to remove accents, e.g. 'é' to 'e':
 

--- a/workflows/docs-audit/AGENTS.md
+++ b/workflows/docs-audit/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+This workspace orchestrates a docs-gap audit across external local repos. It does not own or vendor the source code from those repos.
+
+## Working model
+
+- Deterministic scripts live in `scripts/`.
+- Area manifests live in `manifests/`.
+- Codex prompt templates live in `prompts/`.
+- Run state lives in `state/`.
+- Generated run artifacts live in `artifacts/`.
+
+## Rules for future agents
+
+- Do not copy large code snapshots from the watched repos into this workspace.
+- Keep the deterministic layer deterministic: refresh, extract, fingerprint, select, and update state.
+- Keep semantic reasoning page-scoped and artifact-backed.
+- Reports must describe only what is missing from the docs.
+- When adding a new docs area, prefer a new manifest over changes to the core runner.
+- Keep evidence compact and user-facing where possible.
+- Preserve the distinction between deterministic outputs (`page_bundles`, metadata, state) and LLM outputs (`llm_outputs`, final report).
+
+## Expected output shape
+
+A completed run should leave behind:
+
+- `metadata.json`
+- `selected_pages.json`
+- `page_bundles/*.json`
+- `llm_outputs/*`
+- `report.md`
+
+The report should be concise, grouped by page or subsection, and should not contain implementation plans or doc-fix patches.

--- a/workflows/docs-audit/README.md
+++ b/workflows/docs-audit/README.md
@@ -1,0 +1,323 @@
+# Docs Audit Workspace
+
+This workspace orchestrates a weekly documentation-gap audit across three local repositories:
+
+- `../../../lancedb`
+- `../..`
+- `../../../sophon`
+
+The goal is to find what is missing from the docs, especially conceptual and imperative guidance that exists in code, tests, UI copy, request schemas, config comments, or integration scenarios but is not conveyed clearly in the public docs.
+
+This is a research workflow, not a production service. The design favors:
+
+- compact deterministic preprocessing
+- page-scoped LLM work inside the Codex app
+- saved local artifacts for inspection and reuse
+- simple extension through manifests
+
+## Non-goals
+
+This workspace does not:
+
+- clone or vendor source code from the watched repos
+- attempt to enforce a hard token quota in Codex
+- produce doc fixes automatically
+- behave like a production CI system
+
+## Watched Repos
+
+The watched repos live outside this workspace on purpose.
+
+- `lancedb` is the main SDK/core codebase.
+- `docs` is the Mintlify docs repo and includes tested snippets.
+- `sophon` is the private product repo and contributes user-facing operational truth that may not appear in the public SDK alone.
+
+The audit runner only reads those repos and records refresh status. This workspace stores orchestration code, manifests, prompts, state, and artifacts.
+
+## High-Level Workflow
+
+Each weekly run follows the same sequence:
+
+1. Refresh watched repos with safe fast-forward pulls.
+2. Read the enabled area manifests.
+3. Build deterministic evidence bundles for each page in the selected area.
+4. Compare current evidence fingerprints to the last completed run.
+5. Select pages to audit:
+   - always include pages whose mapped evidence changed
+   - then include one rotating extra page for broader coverage
+   - if no pages changed, the rotating extra page becomes the only selected page
+   - the rotation walks through the pages in manifest order and advances one slot after each completed run
+6. Use Codex LLM passes on the selected page bundles to extract:
+   - code claims
+   - doc claims
+   - candidate gaps and final markdown observations
+7. Save artifacts under a timestamped run directory.
+8. Mark the run complete and update state.
+9. Surface the final markdown report through a Codex inbox item.
+
+## Workspace Layout
+
+- `config.toml`: repo paths, enabled areas, selection rules, and output paths
+- `manifests/`: docs-area manifests
+- `prompts/`: reusable Codex prompt templates
+- `scripts/`: deterministic extraction, refresh, selection, and state utilities
+- `state/`: lightweight run state and rotation cursor
+- `artifacts/`: per-run evidence bundles, LLM outputs, and reports
+- `README.md`: maintainer-oriented workflow and extension guide
+- `AGENTS.md`: instructions for future coding agents
+
+## Deterministic Layer
+
+The deterministic layer is responsible for the parts that should not require semantic interpretation:
+
+- refreshing repos with `git pull --ff-only`
+- reading manifests
+- selecting source files per page
+- hashing file contents and detecting changed pages
+- extracting compact raw signals from docs pages and code-side surfaces
+- writing page-scoped evidence bundles
+- selecting changed pages plus one rotating extra page
+- updating local state after a completed run
+
+The deterministic layer intentionally keeps evidence compact so the LLM does not need to read entire files or repos.
+
+## LLM-Assisted Layer
+
+The semantic layer runs inside Codex through the automation prompt. For each selected page bundle, the LLM should:
+
+1. infer normalized code claims from the evidence bundle
+2. infer normalized doc claims from the docs bundle
+3. identify missing documentation only
+4. write concise markdown observations grouped by page or subsection
+
+The saved artifacts should include:
+
+- normalized code claims
+- normalized doc claims
+- candidate gaps
+- final markdown report
+
+## Running a Manual Audit
+
+From this workspace root:
+
+```bash
+uv run python scripts/run_audit.py prepare --area indexing --refresh
+```
+
+`--area` is the manifest name, not a hardcoded value in the script. The runner loads:
+
+`manifests/<area>.toml`
+
+So `--area indexing` maps to `manifests/indexing.toml`. If you add `manifests/search.toml`, you would run:
+
+```bash
+uv run python scripts/run_audit.py prepare --area search --refresh
+```
+
+This creates a new run directory under `artifacts/runs/<run_id>/` and prints a JSON summary to stdout.
+
+After the LLM phase writes the expected outputs into that run directory, complete the run with:
+
+```bash
+uv run python scripts/run_audit.py complete --run-id <run_id>
+```
+
+To clean up old generated run artifacts, use:
+
+```bash
+uv run python scripts/run_audit.py cleanup --days 30
+```
+
+The retention window is configurable with `--days`, and you can preview deletions without removing anything:
+
+```bash
+uv run python scripts/run_audit.py cleanup --days 14 --dry-run
+```
+
+For manual testing of the fallback path, you can simulate an unrefreshable repo:
+
+```bash
+uv run python scripts/run_audit.py prepare \
+  --area indexing \
+  --refresh \
+  --simulate-refresh-failure docs
+```
+
+## Inspecting Artifacts
+
+Each run directory contains:
+
+- `metadata.json`: run-level metadata, repo refresh results, selection decisions
+- `page_bundles/*.json`: deterministic evidence bundles per page
+- `selected_pages.json`: the pages chosen for the semantic pass
+- `llm_outputs/`: normalized claims, candidate gaps, and other semantic outputs
+- `report.md`: final human-readable report
+
+`artifacts/latest_run.json` points to the most recently completed run.
+
+## Using and Updating Area Manifests
+
+The manifest is the only thing you usually need to change when you want to audit another docs domain. Treat it as a mapping file:
+
+- which docs pages belong to this area
+- which keywords help extract useful evidence
+- which code, tests, snippets, or product surfaces should be compared against those docs pages
+
+You do not need to understand every line in `manifests/indexing.toml` to create another area. Copy it, rename it for the new domain, then update only these parts.
+
+If you want an LLM to help draft or refresh a manifest, use the repo-local skill at [skills/area-manifest-authoring/SKILL.md](skills/area-manifest-authoring/SKILL.md). It tells the agent how to discover candidate files across the watched repos, keep the evidence compact, and validate the generated manifest with `prepare`.
+
+### 1. Pick the manifest filename and area name
+
+The filename is the CLI value for `--area`.
+
+- `manifests/indexing.toml` -> `--area indexing`
+- `manifests/search.toml` -> `--area search`
+- `manifests/storage.toml` -> `--area storage`
+
+Set the top-level fields first:
+
+```toml
+name = "search"
+description = "Audit the search docs against user-facing evidence from lancedb, docs snippets/tests, and sophon."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = ["search", "filter", "rerank"]
+```
+
+What these fields mean:
+
+- `name`: logical name for the area; keep it aligned with the filename
+- `description`: short human-readable summary for metadata and operators
+- `docs_repo`: usually `docs`; this is where the docs pages live
+- `rotation_unit`: currently `page`; leave this alone unless the runner changes
+- `keywords`: broad terms used across the whole area to find evidence
+
+### 2. Define the docs pages in scope
+
+Each `[[pages]]` block describes one public docs page you want audited.
+
+```toml
+[[pages]]
+id = "overview"
+title = "Search Overview"
+path = "docs/search/index.mdx"
+keywords = ["search", "full text search", "hybrid"]
+```
+
+Guidance:
+
+- `id`: short stable identifier used in artifacts and source mappings
+- `title`: readable label for reports
+- `path`: path inside the docs repo
+- `keywords`: page-specific terms that sharpen extraction for this page
+
+Keep page IDs short and stable. If you rename them later, the state history for that page will no longer line up cleanly.
+
+### 3. Map code-side evidence to the right pages
+
+Each `[[sources]]` block says where supporting evidence should come from.
+
+```toml
+[[sources]]
+id = "docs-snippets-tests"
+repo = "docs"
+kind = "snippets_and_tests"
+applies_to = ["overview", "hybrid-search"]
+paths = [
+  "docs/snippets/search.mdx",
+  "tests/py/test_search.py",
+]
+extract_keywords = ["search", "filter", "rerank"]
+```
+
+What to update:
+
+- `id`: stable source label used in page bundles
+- `repo`: one of the repos defined in `config.toml`
+- `kind`: short category label for operators and prompts
+- `applies_to`: page IDs that should receive this evidence
+- `paths`: files inside that repo to scan
+- `extract_keywords`: extra terms for this source only
+
+The important field here is `applies_to`. It is how you decide which evidence should inform which docs page.
+
+### 4. Prefer compact, user-facing evidence
+
+Good source files:
+
+- tested snippets
+- request or config schemas
+- doc comments on public APIs
+- integration tests
+- UI copy and user-facing config
+
+Less useful source files:
+
+- large internal implementation files with no public behavior signals
+- broad directories when one or two targeted files would do
+- duplicated files that say the same thing
+
+The goal is not to prove how the system works internally. The goal is to capture user-visible behavior the docs may be missing.
+
+### 5. Create a new area by copying, then trimming
+
+A practical workflow:
+
+1. Copy `manifests/indexing.toml` to `manifests/<new-area>.toml`.
+2. Rename `name`, `description`, and the page paths.
+3. Delete pages that do not belong to the new domain.
+4. Replace the keywords with terms that actually appear in that domain.
+5. Replace each source block with a small set of relevant files.
+6. Make sure every `applies_to` entry refers to a real page `id`.
+7. Add the area to `enabled_areas` in `config.toml` if your automation depends on that list.
+8. Run `prepare --area <new-area>` and inspect the generated `page_bundles/*.json`.
+
+### 6. Sanity-check the manifest before using it weekly
+
+After adding a new manifest, run:
+
+```bash
+uv run python scripts/run_audit.py prepare --area <new-area>
+```
+
+Then inspect:
+
+- `artifacts/runs/<run_id>/metadata.json`
+- `artifacts/runs/<run_id>/selected_pages.json`
+- `artifacts/runs/<run_id>/page_bundles/*.json`
+
+If the bundles look noisy, the fix is usually one of:
+
+- fewer source files
+- better page keywords
+- better `extract_keywords`
+- tighter `applies_to` mappings
+
+The runner is designed so new docs areas should generally require a new manifest, not new orchestration code.
+
+## Weekly Automation
+
+The weekly Codex automation should use this workspace as its cwd and follow `prompts/weekly_automation.md`.
+
+The automation should:
+
+- review each enabled area manifest before running the audit
+- use `skills/area-manifest-authoring/SKILL.md` to detect docs-page drift and newly relevant evidence files in the watched repos
+- update a manifest when the area boundary or source mapping has materially changed
+- run the deterministic prepare step
+- inspect the generated selected page bundles
+- perform the page-scoped LLM passes
+- write outputs under the run directory
+- keep `report.md` limited to the missing-doc summary itself, not routine workflow or refresh-status narration
+- call the completion step
+- return a concise markdown summary for the inbox item
+
+## Maintainer Notes
+
+- Keep reports focused on what is missing in the docs, not on implementation summaries or fix proposals.
+- Do not spend report tokens on routine success status such as clean repo refreshes.
+- Prefer evidence from doc comments, tested snippets, request schemas, UI copy, config comments, and integration tests over deep implementation internals.
+- If a new feature lands and the docs area should notice it, update the manifest first.
+- If the semantic pass grows too expensive, reduce weekly selection breadth before shrinking evidence quality.

--- a/workflows/docs-audit/config.toml
+++ b/workflows/docs-audit/config.toml
@@ -1,0 +1,25 @@
+version = 1
+enabled_areas = [
+    "indexing",
+    # "search"
+]
+
+[repos.lancedb]
+path = "../../../lancedb"
+
+[repos.docs]
+path = "../.."
+
+[repos.sophon]
+path = "../../../sophon"
+
+[selection]
+rotation_extra_pages = 10
+prefer_changed_pages = true
+
+[paths]
+artifacts_dir = "artifacts/runs"
+latest_run_file = "artifacts/latest_run.json"
+state_file = "state/state.json"
+prompts_dir = "prompts"
+manifests_dir = "manifests"

--- a/workflows/docs-audit/manifests/indexing.toml
+++ b/workflows/docs-audit/manifests/indexing.toml
@@ -1,0 +1,118 @@
+name = "indexing"
+description = "Audit the indexing docs against user-facing evidence from lancedb, docs snippets/tests, and sophon."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = [
+  "index",
+  "IVF",
+  "HNSW",
+  "PQ",
+  "SQ",
+  "RQ",
+  "FTS",
+  "BTree",
+  "Bitmap",
+  "LabelList",
+  "wait_for_index",
+  "index_stats",
+  "prewarm_index",
+  "drop_index",
+  "optimize",
+  "fast_search",
+  "bypass_vector_index",
+  "quantization",
+  "reindexing",
+]
+
+[[pages]]
+id = "overview"
+title = "Indexing Overview"
+path = "docs/indexing/index.mdx"
+keywords = ["IVF", "HNSW", "FTS", "BTree", "Bitmap", "LabelList", "quantization"]
+
+[[pages]]
+id = "vector-index"
+title = "Vector Index"
+path = "docs/indexing/vector-index.mdx"
+keywords = ["IVF", "HNSW", "PQ", "SQ", "RQ", "wait_for_index", "index_stats", "bypass_vector_index"]
+
+[[pages]]
+id = "scalar-index"
+title = "Scalar Index"
+path = "docs/indexing/scalar-index.mdx"
+keywords = ["BTree", "Bitmap", "LabelList", "wait_for_index", "optimize"]
+
+[[pages]]
+id = "fts-index"
+title = "FTS Index"
+path = "docs/indexing/fts-index.mdx"
+keywords = ["FTS", "phrase", "tokenizer", "stop words", "wait_for_index"]
+
+[[pages]]
+id = "reindexing"
+title = "Reindexing"
+path = "docs/indexing/reindexing.mdx"
+keywords = ["optimize", "reindexing", "fast_search", "index_stats"]
+
+[[pages]]
+id = "quantization"
+title = "Quantization"
+path = "docs/indexing/quantization.mdx"
+keywords = ["PQ", "RQ", "num_bits", "num_partitions", "sample_rate", "max_iterations"]
+
+[[pages]]
+id = "gpu-indexing"
+title = "GPU Indexing"
+path = "docs/indexing/gpu-indexing.mdx"
+keywords = ["GPU", "cuda", "mps", "wait_for_index"]
+
+[[sources]]
+id = "lancedb-core-index"
+repo = "lancedb"
+kind = "core_api"
+applies_to = ["overview", "vector-index", "scalar-index", "fts-index", "reindexing", "quantization"]
+paths = [
+  "rust/lancedb/src/index.rs",
+  "rust/lancedb/src/index/vector.rs",
+  "rust/lancedb/src/index/scalar.rs",
+]
+extract_keywords = ["Index", "Builder", "IVF", "HNSW", "FTS", "BTree", "Bitmap", "LabelList", "PQ", "RQ", "SQ"]
+
+[[sources]]
+id = "lancedb-table-query"
+repo = "lancedb"
+kind = "lifecycle_api"
+applies_to = ["overview", "vector-index", "scalar-index", "fts-index", "reindexing", "gpu-indexing"]
+paths = [
+  "rust/lancedb/src/table.rs",
+  "rust/lancedb/src/query.rs",
+  "rust/lancedb/src/index/waiter.rs",
+]
+extract_keywords = ["create_index", "wait_for_index", "index_stats", "drop_index", "prewarm_index", "optimize", "fast_search", "bypass_vector_index"]
+
+[[sources]]
+id = "docs-snippets-tests"
+repo = "docs"
+kind = "snippets_and_tests"
+applies_to = ["overview", "vector-index", "scalar-index", "fts-index", "reindexing", "gpu-indexing"]
+paths = [
+  "docs/snippets/indexing.mdx",
+  "tests/py/test_indexing.py",
+  "tests/py/test_search.py",
+  "tests/ts/ann_indexes.test.ts",
+  "tests/ts/full_text_search.test.ts",
+]
+extract_keywords = ["create_index", "wait_for_index", "index_stats", "optimize", "nprobes", "refine_factor", "FTS"]
+
+[[sources]]
+id = "sophon-api-ui-config"
+repo = "sophon"
+kind = "enterprise_surface"
+applies_to = ["overview", "vector-index", "scalar-index", "fts-index", "reindexing", "gpu-indexing"]
+paths = [
+  "src/rust/phalanx/src/rest/table/create_index.rs",
+  "src/dash/src/components/tables/components/TableIndexTabs.tsx",
+  "helm/lancedb/values.yaml",
+  "src/lancedb_integtest/tests/test_table_lifecycle.py",
+]
+extract_keywords = ["IVF", "HNSW", "RQ", "FTS", "wait_for_index", "index_stats", "scaleout", "GPU", "threshold", "prewarm"]

--- a/workflows/docs-audit/manifests/search.toml
+++ b/workflows/docs-audit/manifests/search.toml
@@ -1,0 +1,145 @@
+name = "search"
+description = "Audit the search docs against user-facing evidence from lancedb, docs snippets/tests, and sophon."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = [
+  "search",
+  "query",
+  "vector",
+  "distance_type",
+  "distance_range",
+  "FTS",
+  "nearest_to_text",
+  "hybrid",
+  "rerank",
+  "filter",
+  "prefilter",
+  "postfilter",
+  "multivector",
+  "with_row_id",
+  "fast_search",
+  "bypass_vector_index",
+  "nprobes",
+  "refine_factor",
+  "explain_plan",
+  "analyze_plan",
+  "SQL",
+  "FlightSQL",
+]
+
+[[pages]]
+id = "overview"
+title = "Search"
+path = "docs/search/index.mdx"
+keywords = ["vector search", "full-text search", "hybrid search", "filtering", "SQL"]
+
+[[pages]]
+id = "vector-search"
+title = "Vector Search"
+path = "docs/search/vector-search.mdx"
+keywords = ["l2", "cosine", "dot", "hamming", "distance_type", "distance_range", "nprobes", "refine_factor", "fast_search", "bypass_vector_index"]
+
+[[pages]]
+id = "full-text-search"
+title = "Full-Text Search (FTS)"
+path = "docs/search/full-text-search.mdx"
+keywords = ["FTS", "BM25", "create_fts_index", "nearest_to_text", "with_position", "phrase query", "fuzzy"]
+
+[[pages]]
+id = "hybrid-search"
+title = "Hybrid Search"
+path = "docs/search/hybrid-search.mdx"
+keywords = ["hybrid", "query_type", "nearest_to_text", "rerank", "RRF", "vector", "text"]
+
+[[pages]]
+id = "filtering"
+title = "Metadata Filtering in LanceDB"
+path = "docs/search/filtering.mdx"
+keywords = ["where", "prefilter", "postfilter", "filter", "limit"]
+
+[[pages]]
+id = "multivector-search"
+title = "Multivector Search"
+path = "docs/search/multivector-search.mdx"
+keywords = ["multivector", "multi_vector", "MaxSim", "cosine", "nearest_to"]
+
+[[pages]]
+id = "optimize-queries"
+title = "Optimize Query Performance"
+path = "docs/search/optimize-queries.mdx"
+keywords = ["explain_plan", "analyze_plan", "KNNVectorDistance", "LanceRead", "AnalyzeExec", "metrics"]
+
+[[pages]]
+id = "sql-overview"
+title = "Query with SQL"
+path = "docs/search/sql/index.mdx"
+keywords = ["SQL", "FlightSQL", "DataFusion", "run_query", "EXPLAIN"]
+
+[[pages]]
+id = "sql-fts"
+title = "Full-Text Search with SQL"
+path = "docs/search/sql/fts-sql.mdx"
+keywords = ["fts()", "UDTF", "phrase query", "with_position", "match", "contains_tokens"]
+
+[[sources]]
+id = "docs-search-snippets-tests"
+repo = "docs"
+kind = "snippets_and_tests"
+applies_to = ["overview", "vector-search", "full-text-search", "hybrid-search", "filtering"]
+paths = [
+  "docs/snippets/search.mdx",
+  "docs/snippets/filtering.mdx",
+  "docs/snippets/full_text_search.mdx",
+  "tests/py/test_search.py",
+  "tests/ts/search.test.ts",
+  "tests/ts/filtering.test.ts",
+  "tests/ts/full_text_search.test.ts",
+]
+extract_keywords = ["distance_type", "distance_range", "nearest_to_text", "nearestToText", "FTS", "hybrid", "prefilter", "postfilter"]
+
+[[sources]]
+id = "lancedb-public-search-tests"
+repo = "lancedb"
+kind = "public_query_tests"
+applies_to = ["overview", "vector-search", "full-text-search", "hybrid-search", "filtering", "multivector-search", "optimize-queries"]
+paths = [
+  "python/python/tests/docs/test_search.py",
+  "python/python/tests/test_hybrid_query.py",
+  "python/python/tests/docs/test_multivector.py",
+  "python/python/tests/test_query.py",
+]
+extract_keywords = ["nearest_to_text", "distance_range", "prefilter", "postfilter", "multivector", "with_row_id", "explain_plan", "analyze_plan", "fast_search", "bypass_vector_index", "nprobes", "refine_factor", "rerank"]
+
+[[sources]]
+id = "lancedb-sql-fts"
+repo = "lancedb"
+kind = "sql_api"
+applies_to = ["sql-overview", "sql-fts"]
+paths = [
+  "rust/lancedb/src/table/datafusion/udtf/fts.rs",
+]
+extract_keywords = ["fts", "FTS query JSON", "table_name", "query_json", "match", "phrase"]
+
+[[sources]]
+id = "sophon-query-api"
+repo = "sophon"
+kind = "enterprise_surface"
+applies_to = ["overview", "vector-search", "full-text-search", "hybrid-search", "filtering", "multivector-search"]
+paths = [
+  "src/rust/phalanx/openapi.yml",
+  "src/rust/phalanx/src/rest/table/query_table.rs",
+  "src/lancedb_integtest/tests/test_search.py",
+]
+extract_keywords = ["full_text_query", "prefilter", "with_row_id", "fast_search", "bypass_vector_index", "nprobes", "refine_factor", "single_vector", "multi_vector"]
+
+[[sources]]
+id = "sophon-query-analysis-sql"
+repo = "sophon"
+kind = "enterprise_analysis_and_sql"
+applies_to = ["optimize-queries", "sql-overview", "sql-fts"]
+paths = [
+  "src/rust/phalanx/src/rest/table/explain_plan.rs",
+  "src/rust/phalanx/src/rest/table/analyze_plan.rs",
+  "src/control_plane/sophon/control_plane/routers_geneva_console/sql.py",
+]
+extract_keywords = ["explain_plan", "analyze_plan", "FlightSQL", "EXPLAIN", "fts"]

--- a/workflows/docs-audit/manifests/table-operations.toml
+++ b/workflows/docs-audit/manifests/table-operations.toml
@@ -1,0 +1,157 @@
+name = "table-operations"
+description = "Audit the table operations docs against user-facing evidence from lancedb, docs snippets/tests, and sophon."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = [
+  "table",
+  "create_table",
+  "open_table",
+  "schema",
+  "update",
+  "merge_insert",
+  "delete",
+  "versioning",
+  "restore",
+  "consistency",
+  "read_consistency_interval",
+  "blob",
+  "on_bad_vectors",
+]
+
+[[pages]]
+id = "overview"
+title = "Basic Table Operations"
+path = "docs/tables/index.mdx"
+keywords = ["create table", "open table", "add rows", "add columns", "drop table", "nested data"]
+
+[[pages]]
+id = "ingesting"
+title = "Ingesting Data"
+path = "docs/tables/create.mdx"
+keywords = ["create_table", "schema", "pandas", "polars", "pyarrow", "pydantic", "create_empty_table", "iterator"]
+
+[[pages]]
+id = "schema-evolution"
+title = "Schema and Data Evolution"
+path = "docs/tables/schema.mdx"
+keywords = ["add_columns", "alter_columns", "drop_columns", "rename", "nullable", "data type"]
+
+[[pages]]
+id = "update-data"
+title = "Updating and Modifying Table Data"
+path = "docs/tables/update.mdx"
+keywords = ["update", "merge_insert", "delete", "when_matched_update_all", "when_not_matched_insert_all", "when_not_matched_by_source_delete"]
+
+[[pages]]
+id = "versioning"
+title = "Versioning and Reproducibility"
+path = "docs/tables/versioning.mdx"
+keywords = ["list_versions", "checkout", "checkout_latest", "restore", "tags"]
+
+[[pages]]
+id = "consistency"
+title = "Consistency"
+path = "docs/tables/consistency.mdx"
+keywords = ["read_consistency_interval", "checkout_latest", "on_bad_vectors", "RemoteTable"]
+
+[[pages]]
+id = "multimodal-data"
+title = "Multimodal Data (Blobs)"
+path = "docs/tables/multimodal.mdx"
+keywords = ["binary", "large_binary", "blob", "lance-encoding:blob", "image_blob"]
+
+[[sources]]
+id = "docs-table-snippets-tests"
+repo = "docs"
+kind = "snippets_and_tests"
+applies_to = ["overview", "ingesting", "schema-evolution", "update-data", "versioning", "consistency"]
+paths = [
+  "docs/snippets/basic_usage.mdx",
+  "docs/snippets/tables.mdx",
+  "tests/py/test_tables.py",
+  "tests/ts/tables.test.ts",
+  "tests/rs/tables.rs",
+]
+extract_keywords = ["create_table", "open_table", "create_empty_table", "add", "add_columns", "alter_columns", "drop_columns", "update", "merge_insert", "delete", "list_versions", "checkout_latest", "restore", "read_consistency_interval", "on_bad_vectors"]
+
+[[sources]]
+id = "docs-multimodal-snippets-tests"
+repo = "docs"
+kind = "multimodal_examples"
+applies_to = ["multimodal-data"]
+paths = [
+  "docs/snippets/multimodal.mdx",
+  "tests/py/test_multimodal.py",
+  "tests/ts/multimodal.test.ts",
+  "tests/rs/multimodal.rs",
+]
+extract_keywords = ["binary", "large_binary", "blob", "lance-encoding:blob", "image_blob", "video"]
+
+[[sources]]
+id = "lancedb-public-table-api"
+repo = "lancedb"
+kind = "public_table_api"
+applies_to = ["overview", "ingesting", "update-data", "versioning", "consistency"]
+paths = [
+  "rust/lancedb/src/table.rs",
+  "rust/lancedb/src/connection/create_table.rs",
+  "python/python/lancedb/table.py",
+  "python/python/lancedb/remote/table.py",
+]
+extract_keywords = ["create_table", "open_table", "create_empty_table", "update", "merge_insert", "delete", "list_versions", "checkout_latest", "restore", "tags", "read_consistency_interval", "on_bad_vectors"]
+
+[[sources]]
+id = "lancedb-schema-and-write-tests"
+repo = "lancedb"
+kind = "public_examples_and_tests"
+applies_to = ["ingesting", "schema-evolution", "update-data"]
+paths = [
+  "rust/lancedb/src/table/schema_evolution.rs",
+  "rust/lancedb/src/table/update.rs",
+  "rust/lancedb/src/table/merge.rs",
+  "rust/lancedb/src/table/delete.rs",
+  "python/python/tests/docs/test_guide_tables.py",
+  "python/python/tests/docs/test_merge_insert.py",
+  "python/python/tests/test_table.py",
+]
+extract_keywords = ["schema", "add_columns", "alter_columns", "drop_columns", "update", "merge_insert", "delete", "nullable", "rename", "cast_to"]
+
+[[sources]]
+id = "sophon-enterprise-table-lifecycle"
+repo = "sophon"
+kind = "enterprise_surface"
+applies_to = ["overview", "ingesting", "update-data"]
+paths = [
+  "src/lancedb_integtest/tests/test_table_lifecycle.py",
+  "src/rust/phalanx/src/rest/table/create_table.rs",
+  "src/rust/phalanx/src/rest/table/update_table.rs",
+  "src/rust/phalanx/src/rest/table/merge_insert_table.rs",
+  "src/rust/phalanx/src/rest/table/delete_from_table.rs",
+]
+extract_keywords = ["create_table", "overwrite", "exist_ok", "update", "merge_insert", "delete", "RemoteTable"]
+
+[[sources]]
+id = "sophon-enterprise-schema-api"
+repo = "sophon"
+kind = "enterprise_schema_surface"
+applies_to = ["schema-evolution"]
+paths = [
+  "src/rust/phalanx/src/rest/table/add_columns.rs",
+  "src/rust/phalanx/src/rest/table/alter_columns.rs",
+  "src/rust/phalanx/src/rest/table/drop_columns.rs",
+]
+extract_keywords = ["add_columns", "alter_columns", "drop_columns", "virtual_column", "nullable", "data_type"]
+
+[[sources]]
+id = "sophon-enterprise-versioning-consistency"
+repo = "sophon"
+kind = "enterprise_versioning_surface"
+applies_to = ["versioning", "consistency"]
+paths = [
+  "src/lancedb_integtest/tests/test_table_versions.py",
+  "src/rust/phalanx/src/rest/table/list_table_versions.rs",
+  "src/rust/phalanx/src/rest/table/restore.rs",
+  "src/rust/phalanx/src/init.rs",
+  "src/rust/phalanx/src/rest/table/declare_table.rs",
+]
+extract_keywords = ["list_versions", "checkout_latest", "restore", "tags", "weak_read_consistency_interval_seconds"]

--- a/workflows/docs-audit/prompts/page_audit_guidelines.md
+++ b/workflows/docs-audit/prompts/page_audit_guidelines.md
@@ -1,0 +1,10 @@
+# Page Audit Guidelines
+
+For each selected page bundle:
+
+- Treat the docs page as the source of current documented truth.
+- Treat the evidence bundle as the source of code-side truth.
+- Look for user-relevant gaps only.
+- Prefer stable concepts and workflows over internal implementation details.
+- Include imperative gaps such as missing lifecycle steps, status checks, fallback behavior, and operational constraints.
+- Keep findings phrased as missing-doc observations, not as remediation tasks.

--- a/workflows/docs-audit/prompts/weekly_automation.md
+++ b/workflows/docs-audit/prompts/weekly_automation.md
@@ -1,0 +1,84 @@
+# Weekly Docs Audit Automation Prompt
+
+You are running the weekly docs-gap audit from this workspace root.
+
+## Objective
+
+Produce a concise markdown report that lists only what is missing from the docs for the selected pages. Focus on conceptual and imperative gaps, not implementation summaries or fix proposals.
+
+This workflow also includes manifest maintenance. Before each audit run, review the enabled area manifests to see whether the docs pages or evidence sources have drifted and update them when needed.
+
+## Files to read first
+
+- `README.md`
+- `AGENTS.md`
+- `config.toml`
+- `prompts/page_audit_guidelines.md`
+- `skills/area-manifest-authoring/SKILL.md`
+
+Then read the manifest file for each area listed in `enabled_areas` in `config.toml`.
+
+## Required workflow
+
+1. Read `config.toml` and determine the enabled areas from `enabled_areas`.
+2. For each enabled area, run a manifest maintenance pass before `prepare`.
+   - Use `skills/area-manifest-authoring/SKILL.md` as the procedure.
+   - Read the current `manifests/<area>.toml`.
+   - Check whether the docs area boundary has changed:
+     - new or renamed docs pages in the same docs section
+     - stale page paths
+     - page IDs that no longer match the current docs layout
+   - Check whether the evidence mapping has drifted:
+     - new snippets, tests, request schemas, config files, UI surfaces, or public API files related to the area
+     - stale source paths that should be removed
+     - source blocks whose `applies_to` mapping is now too broad or too narrow
+   - Keep the manifest compact. Do not add files just because they mention the topic; add them only if they are likely to expose user-visible behavior the docs may be missing.
+   - If the manifest changes, save the updated `manifests/<area>.toml` before preparing the run.
+3. Run the deterministic prepare step for each enabled area.
+   - For the first area, refresh the watched repos:
+     - `uv run python scripts/run_audit.py prepare --area <first-area> --refresh`
+   - For subsequent areas in the same weekly run, skip the refresh to avoid repeating `git pull`:
+     - `uv run python scripts/run_audit.py prepare --area <next-area>`
+4. Read the JSON summary printed by each `prepare` command and locate each new run directory.
+5. For each run directory, read `selected_pages.json` and the corresponding files in `page_bundles/`.
+6. For each selected page bundle:
+   - apply `prompts/page_audit_guidelines.md` as the page-level review rubric
+   - infer normalized code claims from the evidence bundle
+   - infer normalized doc claims from the docs bundle
+   - identify only the missing documentation
+7. Write semantic outputs under `llm_outputs/` in each run directory.
+   - one file per page for code claims
+   - one file per page for doc claims
+   - one file per page for candidate gaps
+8. Write `report.md` in each run directory.
+   - `report.md` is the docs-gap summary only.
+   - Do not include refresh status, manifest-maintenance notes, selected-pages bookkeeping, or any other workflow narration in `report.md`.
+   - Include operational notes only if they materially affected audit quality, such as an unrefreshable repo, missing source files, or a manifest ambiguity that changes confidence in the findings.
+9. Complete each run:
+   - `uv run python scripts/run_audit.py complete --run-id <run_id>`
+10. Return a concise markdown summary suitable for the Codex inbox item.
+
+## Manifest maintenance rules
+
+- Prefer updating the manifest when the docs area or user-facing evidence has clearly evolved.
+- Prefer stability over churn. Do not rewrite a manifest just to reorganize it.
+- Prefer compact source lists over exhaustive source lists.
+- Prefer user-facing evidence over internal implementation detail.
+- If you find a likely new source file but its relevance is ambiguous, mention it in the final summary as a follow-up risk instead of forcing it into the manifest.
+
+## Report rules
+
+- Describe only what is missing from the docs.
+- Group by page or subsection where helpful.
+- Keep the report compact and high signal.
+- Do not propose code changes.
+- Do not rewrite docs.
+- Do not restate successful refreshes, routine maintenance steps, or other low-information operational status.
+- If there were no material gaps for a selected page, omit that page instead of adding filler text.
+- Prefer one short heading plus flat bullets of missing-doc observations.
+
+## Inbox summary rules
+
+- Keep the inbox summary short.
+- Include operational details only when they require attention or explain reduced confidence.
+- Do not echo routine success states such as all repos refreshing cleanly.

--- a/workflows/docs-audit/scripts/run_audit.py
+++ b/workflows/docs-audit/scripts/run_audit.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+"""Deterministic runner for the local docs-gap audit workspace."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = ROOT / "config.toml"
+EXCERPT_LIMIT = 12
+SYMBOL_PATTERNS = [
+    re.compile(r"\b(pub\s+enum|pub\s+struct|pub\s+fn|async\s+fn|fn\s+test_|def\s+test_|test\(|describe\()"),
+]
+ADMONITION_RE = re.compile(r"<(Note|Tip|Warning|Info|Badge)\b")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+IMPORT_RE = re.compile(r"from\s+['\"](/snippets/[^'\"]+)['\"]")
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+@dataclass
+class RepoInfo:
+    name: str
+    path: Path
+
+
+@dataclass
+class Page:
+    id: str
+    title: str
+    path: str
+    keywords: list[str]
+
+
+@dataclass
+class Source:
+    id: str
+    repo: str
+    kind: str
+    applies_to: list[str]
+    paths: list[str]
+    extract_keywords: list[str]
+
+
+@dataclass
+class AreaManifest:
+    name: str
+    description: str
+    docs_repo: str
+    rotation_unit: str
+    keywords: list[str]
+    pages: list[Page]
+    sources: list[Source]
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    config = load_toml(path)
+    config_dir = path.resolve().parent
+    for repo in config.get("repos", {}).values():
+        repo_path = Path(repo["path"])
+        if not repo_path.is_absolute():
+            repo["path"] = str((config_dir / repo_path).resolve())
+    return config
+
+
+def load_manifest(path: Path) -> AreaManifest:
+    data = load_toml(path)
+    pages = [Page(**page) for page in data.get("pages", [])]
+    sources = [Source(**source) for source in data.get("sources", [])]
+    return AreaManifest(
+        name=data["name"],
+        description=data.get("description", ""),
+        docs_repo=data["docs_repo"],
+        rotation_unit=data.get("rotation_unit", "page"),
+        keywords=data.get("keywords", []),
+        pages=pages,
+        sources=sources,
+    )
+
+
+def run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def utc_run_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def line_matches(text: str, keywords: list[str], limit: int = EXCERPT_LIMIT) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    lowered = [kw.lower() for kw in keywords if kw.strip()]
+    if not lowered:
+        return results
+    lines = text.splitlines()
+    for idx, line in enumerate(lines, start=1):
+        line_l = line.lower()
+        matched = [kw for kw in lowered if kw in line_l]
+        if not matched:
+            continue
+        start = max(0, idx - 2)
+        end = min(len(lines), idx + 1)
+        excerpt = "\n".join(lines[start:end]).strip()
+        results.append({
+            "line": idx,
+            "matched_keywords": matched,
+            "excerpt": excerpt,
+        })
+        if len(results) >= limit:
+            break
+    return results
+
+
+def symbol_lines(text: str, limit: int = EXCERPT_LIMIT) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if any(pattern.search(line) for pattern in SYMBOL_PATTERNS):
+            results.append({"line": idx, "text": line.strip()})
+            if len(results) >= limit:
+                break
+    return results
+
+
+def doc_comments(text: str, keywords: list[str], limit: int = EXCERPT_LIMIT) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    comment_prefixes = ("///", "//", "#", "<!--")
+    lowered = [kw.lower() for kw in keywords if kw.strip()]
+    for idx, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped.startswith(comment_prefixes):
+            continue
+        line_l = stripped.lower()
+        matched = [kw for kw in lowered if kw in line_l]
+        if not matched:
+            continue
+        results.append({"line": idx, "matched_keywords": matched, "text": stripped})
+        if len(results) >= limit:
+            break
+    return results
+
+
+def frontmatter(text: str) -> dict[str, Any]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    block = match.group(1)
+    info: dict[str, Any] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        info[key.strip()] = value.strip().strip('"')
+    return info
+
+
+def headings(text: str) -> list[str]:
+    found: list[str] = []
+    for line in text.splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            found.append(match.group(2).strip())
+    return found
+
+
+def snippet_imports(text: str) -> list[str]:
+    return sorted(set(IMPORT_RE.findall(text)))
+
+
+def admonitions(text: str) -> list[str]:
+    return ADMONITION_RE.findall(text)
+
+
+def extract_docs_signals(text: str, keywords: list[str]) -> dict[str, Any]:
+    return {
+        "frontmatter": frontmatter(text),
+        "headings": headings(text),
+        "imports": snippet_imports(text),
+        "admonitions": admonitions(text),
+        "keyword_matches": line_matches(text, keywords),
+    }
+
+
+def extract_code_signals(text: str, keywords: list[str]) -> dict[str, Any]:
+    return {
+        "keyword_matches": line_matches(text, keywords),
+        "doc_comments": doc_comments(text, keywords),
+        "symbol_lines": symbol_lines(text),
+    }
+
+
+def repo_snapshot(repo: RepoInfo, refresh: bool, simulate_failure: bool) -> dict[str, Any]:
+    branch = run_git(repo.path, ["rev-parse", "--abbrev-ref", "HEAD"]) 
+    sha_before = run_git(repo.path, ["rev-parse", "HEAD"])
+    dirty = run_git(repo.path, ["status", "--porcelain"])
+    status = {
+        "repo": repo.name,
+        "path": str(repo.path),
+        "branch": branch.stdout.strip(),
+        "sha_before": sha_before.stdout.strip(),
+        "dirty": bool(dirty.stdout.strip()),
+        "refresh_requested": refresh,
+        "refresh_status": "not_requested",
+        "message": "",
+    }
+    if not refresh:
+        return status
+    if simulate_failure:
+        status["refresh_status"] = "skipped"
+        status["message"] = "Simulated refresh failure"
+        return status
+    pull = run_git(repo.path, ["pull", "--ff-only"])
+    if pull.returncode == 0:
+        sha_after = run_git(repo.path, ["rev-parse", "HEAD"])
+        status["refresh_status"] = "refreshed"
+        status["sha_after"] = sha_after.stdout.strip()
+        status["message"] = pull.stdout.strip() or "fast-forward pull succeeded"
+    else:
+        sha_after = run_git(repo.path, ["rev-parse", "HEAD"])
+        status["refresh_status"] = "skipped"
+        status["sha_after"] = sha_after.stdout.strip()
+        status["message"] = (pull.stderr.strip() or pull.stdout.strip() or "git pull --ff-only failed")
+    return status
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "areas": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_run_id_timestamp(run_id: str) -> datetime | None:
+    try:
+        return datetime.strptime(run_id, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def run_dir_timestamp(run_dir: Path) -> datetime:
+    parsed = parse_run_id_timestamp(run_dir.name)
+    if parsed is not None:
+        return parsed
+    return datetime.fromtimestamp(run_dir.stat().st_mtime, tz=timezone.utc)
+
+
+def clear_deleted_run_references(state_path: Path, deleted_run_ids: set[str]) -> None:
+    state = load_state(state_path)
+    changed = False
+    for area_state in state.get("areas", {}).values():
+        if area_state.get("last_completed_run") not in deleted_run_ids:
+            continue
+        for key in (
+            "last_completed_run",
+            "last_selected_pages",
+            "last_changed_pages",
+            "last_report_path",
+            "completed_at",
+        ):
+            if key in area_state:
+                del area_state[key]
+                changed = True
+    if changed:
+        write_json(state_path, state)
+
+
+def refresh_latest_run_file(latest_run_file: Path, runs_dir: Path, deleted_run_ids: set[str]) -> None:
+    if not latest_run_file.exists():
+        return
+    latest = json.loads(latest_run_file.read_text(encoding="utf-8"))
+    if latest.get("run_id") not in deleted_run_ids:
+        return
+    remaining_runs = sorted(path for path in runs_dir.iterdir() if path.is_dir())
+    if not remaining_runs:
+        latest_run_file.unlink()
+        return
+    newest = remaining_runs[-1]
+    report_path = newest / "report.md"
+    replacement = {
+        "run_id": newest.name,
+        "run_dir": str(newest),
+    }
+    metadata_path = newest / "metadata.json"
+    if metadata_path.exists():
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        replacement["area"] = metadata.get("area", "")
+        replacement["completed_at"] = metadata.get("created_at", "")
+    if report_path.exists():
+        replacement["report_path"] = str(report_path)
+    write_json(latest_run_file, replacement)
+
+
+def sources_for_page(manifest: AreaManifest, page_id: str) -> list[Source]:
+    results = []
+    for source in manifest.sources:
+        if page_id in source.applies_to or "*" in source.applies_to:
+            results.append(source)
+    return results
+
+
+def collect_page_bundle(
+    manifest: AreaManifest,
+    config: dict[str, Any],
+    page: Page,
+    repos: dict[str, RepoInfo],
+) -> dict[str, Any]:
+    docs_repo = repos[manifest.docs_repo]
+    page_path = docs_repo.path / page.path
+    page_text = read_text(page_path)
+    docs_keywords = list(dict.fromkeys(manifest.keywords + page.keywords))
+    docs_signals = extract_docs_signals(page_text, docs_keywords)
+    evidence: list[dict[str, Any]] = []
+    fingerprint_parts = [sha256_file(page_path)]
+    for source in sources_for_page(manifest, page.id):
+        repo = repos[source.repo]
+        source_keywords = list(dict.fromkeys(docs_keywords + source.extract_keywords))
+        for rel_path in source.paths:
+            abs_path = repo.path / rel_path
+            if not abs_path.exists():
+                evidence.append({
+                    "source_id": source.id,
+                    "repo": source.repo,
+                    "kind": source.kind,
+                    "path": rel_path,
+                    "missing": True,
+                })
+                fingerprint_parts.append(sha256_text(f"missing:{source.repo}:{rel_path}"))
+                continue
+            text = read_text(abs_path)
+            fingerprint_parts.append(sha256_file(abs_path))
+            evidence.append({
+                "source_id": source.id,
+                "repo": source.repo,
+                "kind": source.kind,
+                "path": rel_path,
+                "missing": False,
+                "signals": extract_code_signals(text, source_keywords),
+            })
+    fingerprint = sha256_text("\n".join(fingerprint_parts))
+    return {
+        "area": manifest.name,
+        "page_id": page.id,
+        "page_title": page.title,
+        "page_path": page.path,
+        "page_keywords": docs_keywords,
+        "page_fingerprint": fingerprint,
+        "docs_signals": docs_signals,
+        "evidence": evidence,
+    }
+
+
+def select_pages(
+    pages: list[Page],
+    fingerprints: dict[str, str],
+    previous_fingerprints: dict[str, str],
+    rotation_index: int,
+    rotation_extra_pages: int,
+) -> tuple[list[str], list[str], int]:
+    ordered_ids = [page.id for page in pages]
+    changed = [page_id for page_id in ordered_ids if previous_fingerprints.get(page_id) != fingerprints[page_id]]
+    selected = list(changed)
+    next_index = rotation_index
+    extras_added = 0
+    while ordered_ids and extras_added < rotation_extra_pages:
+        candidate = ordered_ids[next_index % len(ordered_ids)]
+        next_index = (next_index + 1) % len(ordered_ids)
+        if candidate in selected:
+            if len(selected) == len(ordered_ids):
+                break
+            continue
+        selected.append(candidate)
+        extras_added += 1
+    return changed, selected, next_index
+
+
+def prepare(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    repos = {
+        name: RepoInfo(name=name, path=Path(info["path"]))
+        for name, info in config["repos"].items()
+    }
+    manifest = load_manifest(ROOT / config["paths"]["manifests_dir"] / f"{args.area}.toml")
+    state_path = ROOT / config["paths"]["state_file"]
+    state = load_state(state_path)
+    area_state = state.get("areas", {}).get(args.area, {})
+    previous_fingerprints = area_state.get("page_fingerprints", {})
+    rotation_index = int(area_state.get("rotation_index", 0))
+    run_id = utc_run_id()
+    run_dir = ROOT / config["paths"]["artifacts_dir"] / run_id
+    page_dir = run_dir / "page_bundles"
+    llm_dir = run_dir / "llm_outputs"
+    ensure_dir(page_dir)
+    ensure_dir(llm_dir)
+
+    refresh_results = []
+    simulated = set(args.simulate_refresh_failure or [])
+    for repo in repos.values():
+        refresh_results.append(repo_snapshot(repo, args.refresh, repo.name in simulated))
+
+    page_fingerprints: dict[str, str] = {}
+    page_bundles: dict[str, dict[str, Any]] = {}
+    for page in manifest.pages:
+        bundle = collect_page_bundle(manifest, config, page, repos)
+        page_bundles[page.id] = bundle
+        page_fingerprints[page.id] = bundle["page_fingerprint"]
+        write_json(page_dir / f"{page.id}.json", bundle)
+
+    changed_pages, selected_pages, next_rotation_index = select_pages(
+        manifest.pages,
+        page_fingerprints,
+        previous_fingerprints,
+        rotation_index,
+        int(config["selection"]["rotation_extra_pages"]),
+    )
+
+    selected_payload = {
+        "area": args.area,
+        "changed_pages": changed_pages,
+        "selected_pages": selected_pages,
+    }
+    write_json(run_dir / "selected_pages.json", selected_payload)
+
+    metadata = {
+        "run_id": run_id,
+        "area": args.area,
+        "manifest": {
+            "name": manifest.name,
+            "description": manifest.description,
+            "pages": [page.id for page in manifest.pages],
+        },
+        "refresh": refresh_results,
+        "page_fingerprints": page_fingerprints,
+        "rotation": {
+            "previous_index": rotation_index,
+            "next_index": next_rotation_index,
+            "rotation_extra_pages": int(config["selection"]["rotation_extra_pages"]),
+        },
+        "selected_pages": selected_pages,
+        "changed_pages": changed_pages,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    write_json(run_dir / "metadata.json", metadata)
+
+    summary = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "selected_pages": selected_pages,
+        "changed_pages": changed_pages,
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def complete(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    state_path = ROOT / config["paths"]["state_file"]
+    latest_run_file = ROOT / config["paths"]["latest_run_file"]
+    run_dir = ROOT / config["paths"]["artifacts_dir"] / args.run_id
+    metadata_path = run_dir / "metadata.json"
+    selected_path = run_dir / "selected_pages.json"
+    report_path = run_dir / "report.md"
+    if not metadata_path.exists():
+        raise SystemExit(f"Missing metadata.json for run {args.run_id}")
+    if not selected_path.exists():
+        raise SystemExit(f"Missing selected_pages.json for run {args.run_id}")
+    if not report_path.exists():
+        raise SystemExit(f"Missing report.md for run {args.run_id}")
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    selected = json.loads(selected_path.read_text(encoding="utf-8"))
+    state = load_state(state_path)
+    areas = state.setdefault("areas", {})
+    area_state = areas.setdefault(metadata["area"], {})
+    area_state["page_fingerprints"] = metadata["page_fingerprints"]
+    area_state["rotation_index"] = metadata["rotation"]["next_index"]
+    area_state["last_completed_run"] = args.run_id
+    area_state["last_selected_pages"] = selected["selected_pages"]
+    area_state["last_changed_pages"] = selected["changed_pages"]
+    area_state["last_report_path"] = str(report_path)
+    area_state["completed_at"] = datetime.now(timezone.utc).isoformat()
+    write_json(state_path, state)
+    write_json(
+        latest_run_file,
+        {
+            "run_id": args.run_id,
+            "area": metadata["area"],
+            "run_dir": str(run_dir),
+            "report_path": str(report_path),
+            "completed_at": area_state["completed_at"],
+        },
+    )
+    print(json.dumps({"completed": True, "run_id": args.run_id, "run_dir": str(run_dir)}, indent=2))
+    return 0
+
+
+def cleanup(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config))
+    runs_dir = ROOT / config["paths"]["artifacts_dir"]
+    latest_run_file = ROOT / config["paths"]["latest_run_file"]
+    state_path = ROOT / config["paths"]["state_file"]
+    if not runs_dir.exists():
+        print(json.dumps({"deleted_run_ids": [], "dry_run": args.dry_run, "kept_run_ids": []}, indent=2))
+        return 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.days)
+    run_dirs = sorted(path for path in runs_dir.iterdir() if path.is_dir())
+    to_delete = [run_dir for run_dir in run_dirs if run_dir_timestamp(run_dir) < cutoff]
+    kept = [run_dir.name for run_dir in run_dirs if run_dir not in to_delete]
+    deleted = [run_dir.name for run_dir in to_delete]
+
+    if not args.dry_run:
+        for run_dir in to_delete:
+            shutil.rmtree(run_dir)
+        deleted_ids = set(deleted)
+        clear_deleted_run_references(state_path, deleted_ids)
+        refresh_latest_run_file(latest_run_file, runs_dir, deleted_ids)
+
+    print(
+        json.dumps(
+            {
+                "cutoff": cutoff.isoformat(),
+                "days": args.days,
+                "dry_run": args.dry_run,
+                "deleted_run_ids": deleted,
+                "kept_run_ids": kept,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local docs-gap audit runner")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to config.toml")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser("prepare", help="Refresh repos, build evidence bundles, and select pages")
+    prepare_parser.add_argument("--area", required=True, help="Area manifest name, e.g. indexing")
+    prepare_parser.add_argument("--refresh", action="store_true", help="Attempt git pull --ff-only on watched repos")
+    prepare_parser.add_argument(
+        "--simulate-refresh-failure",
+        action="append",
+        choices=["lancedb", "docs", "sophon"],
+        help="Simulate an unrefreshable repo for manual validation",
+    )
+    prepare_parser.set_defaults(func=prepare)
+
+    complete_parser = subparsers.add_parser("complete", help="Mark a run complete and update state")
+    complete_parser.add_argument("--run-id", required=True, help="Run ID returned by prepare")
+    complete_parser.set_defaults(func=complete)
+
+    cleanup_parser = subparsers.add_parser(
+        "cleanup",
+        help="Delete old generated run artifacts under artifacts/runs",
+    )
+    cleanup_parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Delete run directories older than this many days (default: 30)",
+    )
+    cleanup_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which runs would be deleted without removing anything",
+    )
+    cleanup_parser.set_defaults(func=cleanup)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflows/docs-audit/skills/area-manifest-authoring/SKILL.md
+++ b/workflows/docs-audit/skills/area-manifest-authoring/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: area-manifest-authoring
+description: Use when creating or updating a docs audit area manifest in this repo, especially for a new docs domain or when you need to discover likely source files across the watched repos and draft manifests/<area>.toml.
+---
+
+# Area Manifest Authoring
+
+Use this skill to create or refresh `manifests/<area>.toml` for the docs-audit workspace.
+
+This repo does not vendor the watched repos. The job is to map a docs domain to compact, user-facing evidence in the external repos.
+
+## Read first
+
+Before editing a manifest, read:
+
+- `README.md`
+- `AGENTS.md`
+- `config.toml`
+- the current manifest if one already exists at `manifests/<area>.toml`
+
+## Goal
+
+Produce a manifest that:
+
+- defines the docs pages in the area
+- maps each page to a small set of relevant evidence files
+- prefers user-facing surfaces over deep implementation internals
+- is easy to maintain when repos evolve
+
+## Workflow
+
+### 1. Fix the area boundary
+
+Identify:
+
+- the manifest filename and area name
+- the docs section or path prefix in the docs repo
+- the pages that should be audited together
+
+If the boundary is fuzzy, prefer a narrower area. Smaller manifests are easier to keep accurate.
+
+### 2. Start from the docs pages, not from code
+
+For the target docs domain:
+
+- list the public docs pages that belong in the area
+- capture one stable `id` per page
+- extract a few page-specific keywords from titles, headings, callouts, and API names
+
+Keep page IDs short and stable. They become artifact filenames and state keys.
+
+### 3. Discover candidate evidence across repos
+
+Search all watched repos for user-facing signals tied to the area.
+
+Start with targeted searches:
+
+- docs repo: snippets, tests, nearby pages
+- lancedb repo: public API files, doc comments, tests, lifecycle code
+- sophon repo: request schemas, UI copy, config, integration tests
+
+Useful commands:
+
+```bash
+rg -n "keyword1|keyword2|keyword3" <docs-repo> <lancedb-repo> <sophon-repo>
+rg --files <docs-repo> <lancedb-repo> <sophon-repo> | rg "search|index|storage"
+```
+
+Resolve those repo roots from `config.toml` before you search.
+
+When searching for future drift or newly added files:
+
+- search by feature nouns and API verbs, not just the current filename
+- search neighboring directories to the current sources
+- look for tests and snippets added after the original manifest was written
+- look for new UI or config surfaces that expose user-visible behavior
+
+Do not try to include every related file. Include only the files that are likely to expose missing documentation.
+
+### 4. Select compact evidence
+
+Prefer files that reveal stable, user-visible behavior:
+
+- tested snippets
+- integration tests
+- request and config schemas
+- public API surfaces and doc comments
+- UI copy and operational config
+
+Avoid bloating the manifest with:
+
+- large internal implementation files that expose little user-facing behavior
+- duplicate files that repeat the same concepts
+- broad file lists when one or two narrower files would carry the same signal
+
+In general, a source block should stay compact. Split sources by surface type when that keeps the manifest easier to reason about.
+
+### 5. Draft the manifest
+
+Create or update `manifests/<area>.toml` with:
+
+- top-level metadata:
+  - `name`
+  - `description`
+  - `docs_repo`
+  - `rotation_unit`
+  - `keywords`
+- one `[[pages]]` block per docs page
+- one or more `[[sources]]` blocks that map evidence to the right page IDs
+
+Use `applies_to` deliberately. That is the main control for keeping bundles relevant.
+
+## Mechanical checks
+
+Before finishing, verify:
+
+- the manifest filename matches the intended CLI area
+- every `repo` exists in `config.toml`
+- every page `id` is unique
+- every `applies_to` entry points to a real page `id` or `*`
+- every `path` exists in the referenced repo
+- keywords are concise and domain-specific rather than a long dump of terms
+
+If you create a new area, also update `enabled_areas` in `config.toml` if the automation or operators expect it.
+
+## Validation loop
+
+After drafting the manifest, run:
+
+```bash
+uv run python scripts/run_audit.py prepare --area <area>
+```
+
+Inspect:
+
+- `artifacts/runs/<run_id>/metadata.json`
+- `artifacts/runs/<run_id>/selected_pages.json`
+- `artifacts/runs/<run_id>/page_bundles/*.json`
+
+If the bundles are noisy, tighten:
+
+- page keywords
+- source `extract_keywords`
+- `applies_to`
+- source file selection
+
+If the bundles are sparse, add the smallest missing user-facing source that improves evidence quality.
+
+## Output contract
+
+When using this skill, the final result should:
+
+- create or update `manifests/<area>.toml`
+- mention the main assumptions made about area boundaries
+- call out any likely blind spots or missing repos/files that should be reviewed later
+
+## Request template
+
+Use a request like:
+
+```text
+Use skills/area-manifest-authoring/SKILL.md to create or refresh manifests/<area>.toml for the <domain> docs. Scan the watched repos for likely user-facing evidence, keep the source list compact, and validate the manifest by running the prepare step.
+```


### PR DESCRIPTION
## Summary

Addresses reviewer feedback the source code. Prose/table edits only — no snippet regeneration needed.

- **Vector index** — `IVF_FLAT` + `hamming` is the only supported path for binary vectors; quantized index types restrict `distance_type` to `l2`/`cosine`/`dot`.
- **Vector index** — Multivector indexing requires `cosine` at index-creation time; explains why `bypass_vector_index()` is the escape hatch for non-cosine multivector queries.
- **FTS** — Adds `custom_stop_words`, `min_ngram_length`, `max_ngram_length`, and `prefix_only` to the FTS parameters table, with `custom_stop_words` parity on the full-text-search guide.
- **Quantization** — Adds `IVF_HNSW_SQ` and `IVF_HNSW_PQ` alongside `IVF_PQ` and `IVF_RQ`, and frames the two axes (IVF vs. IVF+HNSW; PQ/RQ/SQ).

## Test plan

- [x] `mintlify dev` — load each edited page; confirm tables render and cross-links resolve (`/search/multivector-search`, `/indexing/vector-index#choose-the-right-index`).
- [x] Eyeball binary-vector Warning and multivector Note placement on the vector-index page.
- [x] Confirm new FTS rows show in the parameters table on `fts-index.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)