### PR TITLE
Docs updates to reranker section from audit workflow

### DIFF
--- a/docs/reranking/custom-reranker.mdx
+++ b/docs/reranking/custom-reranker.mdx
@@ -5,9 +5,16 @@ description: Learn how to create custom rerankers in LanceDB by extending the ba
 icon: "code"
 ---
 
-You can build your own custom reranker in LanceDB by subclassing the `Reranker` class and implementing the
-`rerank_hybrid()` method. Optionally, you can also implement the `rerank_vector()` and `rerank_fts()`
-methods if you want to support reranking for vector and FTS search separately.
+You can build your own custom reranker in LanceDB by subclassing the base `Reranker` class. At a
+minimum, you need to implement `rerank_hybrid()`, which is the logic that combines vector and
+full-text search results. Beyond that, you can optionally implement `rerank_vector()` and
+`rerank_fts()` if you want your reranker to also handle pure vector or pure full-text searches.
+
+Decide up front which surfaces — hybrid, pure vector, or pure full-text — your reranker should
+cover, and only override the ones you need. The base class leaves `rerank_vector()` and
+`rerank_fts()` unimplemented, so calling `.rerank(...)` on a single-modality search you haven't
+overridden raises `NotImplementedError` rather than silently returning unsorted results. That's a
+useful guard, but worth knowing about before you wire up a query path you didn't plan for.
 
 ## Interface
 
@@ -17,6 +24,11 @@ the results and removes the duplicates without taking the scores into considerat
 first copy of the row encountered. This works well in cases that don't require the scores of semantic
 and full-text search to combine the results. If you want to use the scores or want to support
 `return_score="all"`, you'll need to implement your own merging algorithm.
+
+Whichever methods you override, your reranker has one job on the way out: attach a
+`_relevance_score` column with the most relevant rows at the top. LanceDB will reject the result
+if that column is missing, and downstream `.limit(...)` calls trust the order you return, so
+sort descending before handing the table back.
 
 Below, we show the pseudocode of a custom reranker that combines the results of semantic and full-text
 search using a linear combination of the scores:

--- a/docs/reranking/eval.mdx
+++ b/docs/reranking/eval.mdx
@@ -15,9 +15,26 @@ Combining results from multiple searches thus requires a reranking step.
 
 There are two common approaches for reranking search results from multiple sources.
 
-- **Score-based**: Calculate final relevance scores based on a weighted linear combination of individual search algorithm scores. Example: Weighted linear combination of semantic search & keyword-based search results.
+- **Score-based**: Calculate final relevance scores from the individual search algorithm scores. Examples: Reciprocal Rank Fusion (the default in LanceDB), and weighted linear combination of semantic & keyword-based search scores.
 
-- **Relevance-based**: Discards the existing scores and calculates the relevance of each search result-query pair. Example: Cross Encoder models
+- **Relevance-based**: Discards the existing scores and calculates the relevance of each search result-query pair. Example: Cross Encoder models
+
+<Info>
+If you call `.rerank()` on a hybrid query without passing a reranker, LanceDB defaults to
+`RRFReranker()` — a score-based reranker that uses Reciprocal Rank Fusion. This is the
+score-based path most readers encounter first; `LinearCombinationReranker` is an alternative
+score-based strategy you opt into explicitly.
+</Info>
+
+The hybrid `rerank(...)` method also accepts a `normalize` argument that controls how the raw
+vector and FTS scores are made comparable before reranking:
+
+- `normalize="score"` (the default) — normalizes the raw vector and FTS scores directly.
+- `normalize="rank"` — converts each result list to ranks first, then normalizes.
+
+This choice materially affects score-based rerankers (such as `LinearCombinationReranker`), so
+when you evaluate score-based strategies, treat `normalize` as a tunable hyperparameter
+alongside the reranker itself.
 
 Even though there may many more strategies for reranking, there are no "universally best"
 ones that work well for all cases, because they be dataset or application specific.

--- a/docs/reranking/index.mdx
+++ b/docs/reranking/index.mdx
@@ -42,6 +42,16 @@ LanceDB supports several rerankers out of the box. Here are a few examples:
 
 You can find more details about these and other rerankers in the [integrations](/integrations/reranking) section.
 
+<Note>
+**SDK coverage differs across languages**
+
+The provider-specific rerankers in the table above
+(`CohereReranker`, `CrossEncoderReranker`, `ColbertReranker`, and others under `lancedb.rerankers`)
+are currently **Python-only**. The TypeScript and Rust SDKs currently expose the generic `Reranker`
+interface (`rerankHybrid` / `rerank_hybrid`) and the built-in `RRFReranker`. To use a
+model-based reranker from TypeScript or Rust, you must implement the `Reranker` interface yourself.
+</Note>
+
 
 ### Multi-vector reranking
 Most rerankers support reranking based on multiple vectors. To rerank based on multiple vectors, you can pass a list of vectors to the `rerank` method. Here's an example of how to rerank based on multiple vector columns using the `CrossEncoderReranker`:
@@ -54,13 +64,21 @@ reranker = CrossEncoderReranker()
 
 query = "hello"
 
-res1 = table.search(query, vector_column_name="vector").limit(3)
-res2 = table.search(query, vector_column_name="text_vector").limit(3)
-res3 = table.search(query, vector_column_name="meta_vector").limit(3)
+# `deduplicate=True` requires `_rowid` on every input result set,
+# so call `.with_row_id(True)` on each search before passing it in.
+res1 = table.search(query, vector_column_name="vector").limit(3).with_row_id(True)
+res2 = table.search(query, vector_column_name="text_vector").limit(3).with_row_id(True)
+res3 = table.search(query, vector_column_name="meta_vector").limit(3).with_row_id(True)
 
-reranked = reranker.rerank_multivector([res1, res2, res3],  deduplicate=True)
+reranked = reranker.rerank_multivector([res1, res2, res3], deduplicate=True)
 ```
 </CodeGroup>
+
+- Passing `deduplicate=True` to `rerank_multivector(...)` raises a `ValueError` if any of the
+input result sets is missing the `_rowid` column. Therefore, it's recommended to add `.with_row_id(True)` to every
+`table.search(...)` call before reranking, or omit `deduplicate=True` if you don't need it.
+- `RRFReranker.rerank_multivector(...)` always requires `_rowid` on its inputs, regardless of
+the `deduplicate` flag.
 
 ## Creating Custom Rerankers
 

--- a/workflows/docs-audit/README.md
+++ b/workflows/docs-audit/README.md
@@ -115,13 +115,16 @@ So `--area indexing` maps to `manifests/indexing.toml`. If you add `manifests/se
 uv run python scripts/run_audit.py prepare --area search --refresh
 ```
 
-This creates a new run directory under `artifacts/runs/<run_id>/` and prints a JSON summary to stdout.
+This creates a pending run directory under `artifacts/pending/<run_id>/` and prints a JSON summary to stdout.
 
-After the LLM phase writes the expected outputs into that run directory, complete the run with:
+After the LLM phase writes the expected outputs into that pending run directory, complete the run with:
 
 ```bash
 uv run python scripts/run_audit.py complete --run-id <run_id>
 ```
+
+Completion publishes the directory to `artifacts/runs/<run_id>/`. Directories under `artifacts/runs/`
+are completed audit artifacts and should contain `report.md`.
 
 To clean up old generated run artifacts, use:
 
@@ -146,7 +149,7 @@ uv run python scripts/run_audit.py prepare \
 
 ## Inspecting Artifacts
 
-Each run directory contains:
+Each completed run directory under `artifacts/runs/<run_id>/` contains:
 
 - `metadata.json`: run-level metadata, repo refresh results, selection decisions
 - `page_bundles/*.json`: deterministic evidence bundles per page
@@ -155,6 +158,10 @@ Each run directory contains:
 - `report.md`: final human-readable report
 
 `artifacts/latest_run.json` points to the most recently completed run.
+
+Pending run directories under `artifacts/pending/<run_id>/` are working directories from `prepare`.
+They are used for manifest validation and LLM drafting, and are not considered completed artifacts
+until `complete` publishes them.
 
 ## Using and Updating Area Manifests
 
@@ -272,7 +279,7 @@ A practical workflow:
 5. Replace each source block with a small set of relevant files.
 6. Make sure every `applies_to` entry refers to a real page `id`.
 7. Add the area to `enabled_areas` in `config.toml` if your automation depends on that list.
-8. Run `prepare --area <new-area>` and inspect the generated `page_bundles/*.json`.
+8. Run `prepare --area <new-area>` and inspect the generated `page_bundles/*.json` in the printed pending `run_dir`.
 
 ### 6. Sanity-check the manifest before using it weekly
 
@@ -284,9 +291,10 @@ uv run python scripts/run_audit.py prepare --area <new-area>
 
 Then inspect:
 
-- `artifacts/runs/<run_id>/metadata.json`
-- `artifacts/runs/<run_id>/selected_pages.json`
-- `artifacts/runs/<run_id>/page_bundles/*.json`
+- the `run_dir` printed by `prepare` (normally `artifacts/pending/<run_id>`)
+- `<run_dir>/metadata.json`
+- `<run_dir>/selected_pages.json`
+- `<run_dir>/page_bundles/*.json`
 
 If the bundles look noisy, the fix is usually one of:
 

--- a/workflows/docs-audit/manifests/reranking.toml
+++ b/workflows/docs-audit/manifests/reranking.toml
@@ -1,0 +1,108 @@
+name = "reranking"
+description = "Audit the user-guide reranking docs against public SDK reranker APIs, tested behavior, and user-facing examples in lancedb and docs snippets/tests."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = [
+  "rerank_hybrid",
+  "rerank_vector",
+  "rerank_fts",
+  "rerank_multivector",
+  "return_score",
+  "RRFReranker",
+  "MRRReranker",
+  "LinearCombinationReranker",
+]
+
+[[pages]]
+id = "overview"
+title = "Reranking Search Results"
+path = "docs/reranking/index.mdx"
+keywords = ["reranking", "CohereReranker", "CrossEncoderReranker", "ColbertReranker", "rerank_multivector", "deduplicate"]
+
+[[pages]]
+id = "custom-reranker"
+title = "Building Custom Rerankers"
+path = "docs/reranking/custom-reranker.mdx"
+keywords = ["custom reranker", "Reranker", "rerank_hybrid", "rerank_vector", "rerank_fts", "merge_results", "return_score"]
+
+[[pages]]
+id = "evaluation"
+title = "Evaluating Hybrid Search Performance"
+path = "docs/reranking/eval.mdx"
+keywords = ["hybrid search", "reranking strategies", "score-based", "relevance-based", "Linear Combination", "Cross Encoder", "Cohere", "ColBERT"]
+
+[[sources]]
+id = "lancedb-python-reranker-core"
+repo = "lancedb"
+kind = "public_python_api"
+applies_to = ["overview", "custom-reranker", "evaluation"]
+paths = [
+  "python/python/lancedb/rerankers/__init__.py",
+  "python/python/lancedb/rerankers/base.py",
+  "python/python/lancedb/rerankers/linear_combination.py",
+  "python/python/lancedb/rerankers/mrr.py",
+  "python/python/lancedb/rerankers/rrf.py",
+  "python/python/lancedb/query.py",
+]
+extract_keywords = ["Reranker", "rerank_hybrid", "rerank_vector", "rerank_fts", "merge_results", "rerank_multivector", "return_score", "_relevance_score", "RRFReranker", "MRRReranker", "LinearCombinationReranker"]
+
+[[sources]]
+id = "lancedb-python-reranker-tests"
+repo = "lancedb"
+kind = "public_python_tests"
+applies_to = ["overview", "custom-reranker", "evaluation"]
+paths = [
+  "python/python/tests/test_rerankers.py",
+  "python/python/tests/test_hybrid_query.py",
+]
+extract_keywords = ["return_score", "_relevance_score", "rerank_multivector", "deduplicate", "RRFReranker", "MRRReranker", "LinearCombinationReranker", "CohereReranker", "CrossEncoderReranker", "ColbertReranker"]
+
+[[sources]]
+id = "lancedb-python-provider-rerankers-overview"
+repo = "lancedb"
+kind = "public_python_api"
+applies_to = ["overview"]
+paths = [
+  "python/python/lancedb/rerankers/cohere.py",
+  "python/python/lancedb/rerankers/colbert.py",
+  "python/python/lancedb/rerankers/cross_encoder.py",
+]
+extract_keywords = ["CohereReranker", "ColbertReranker", "CrossEncoderReranker", "model_name", "return_score", "_relevance_score"]
+
+[[sources]]
+id = "lancedb-typescript-rust-rerankers"
+repo = "lancedb"
+kind = "typescript_rust_api"
+applies_to = ["overview", "custom-reranker"]
+paths = [
+  "nodejs/lancedb/rerankers/index.ts",
+  "nodejs/lancedb/rerankers/rrf.ts",
+  "nodejs/__test__/rerankers.test.ts",
+  "rust/lancedb/src/rerankers.rs",
+  "rust/lancedb/src/rerankers/rrf.rs",
+  "rust/lancedb/src/query.rs",
+]
+extract_keywords = ["Reranker", "RRFReranker", "rerankHybrid", "rerank_hybrid", "_relevance_score", "custom reranker"]
+
+[[sources]]
+id = "lancedb-generated-js-reranker-docs"
+repo = "lancedb"
+kind = "generated_api_docs"
+applies_to = ["overview"]
+paths = [
+  "docs/src/js/namespaces/rerankers/README.md",
+  "docs/src/js/namespaces/rerankers/interfaces/Reranker.md",
+  "docs/src/js/namespaces/rerankers/classes/RRFReranker.md",
+  "docs/src/js/classes/VectorQuery.md",
+]
+extract_keywords = ["rerankers", "Reranker", "RRFReranker", "create", "rerank"]
+
+[[sources]]
+id = "sophon-reranking-example-surface"
+repo = "sophon"
+kind = "enterprise_surface"
+applies_to = ["overview"]
+paths = [
+  "src/dash/src/components/examples/components/ExampleCards.tsx",
+]
+extract_keywords = ["reranking", "RRF", "hybrid-search", "custom reranking"]

--- a/workflows/docs-audit/prompts/weekly_automation.md
+++ b/workflows/docs-audit/prompts/weekly_automation.md
@@ -39,23 +39,27 @@ Then read the manifest file for each area listed in `enabled_areas` in `config.t
      - `uv run python scripts/run_audit.py prepare --area <first-area> --refresh`
    - For subsequent areas in the same weekly run, skip the refresh to avoid repeating `git pull`:
      - `uv run python scripts/run_audit.py prepare --area <next-area>`
-4. Read the JSON summary printed by each `prepare` command and locate each new run directory.
-5. For each run directory, read `selected_pages.json` and the corresponding files in `page_bundles/`.
+4. Read the JSON summary printed by each `prepare` command and locate each pending run directory.
+   - Use the printed `run_dir`; it should point under `artifacts/pending/<run_id>`.
+   - Do not create or write directly under `artifacts/runs/<run_id>` before completion.
+5. For each pending run directory, read `selected_pages.json` and the corresponding files in `page_bundles/`.
 6. For each selected page bundle:
    - apply `prompts/page_audit_guidelines.md` as the page-level review rubric
    - infer normalized code claims from the evidence bundle
    - infer normalized doc claims from the docs bundle
    - identify only the missing documentation
-7. Write semantic outputs under `llm_outputs/` in each run directory.
+7. Write semantic outputs under `llm_outputs/` in each pending run directory.
    - one file per page for code claims
    - one file per page for doc claims
    - one file per page for candidate gaps
-8. Write `report.md` in each run directory.
+8. Write `report.md` in each pending run directory.
    - `report.md` is the docs-gap summary only.
    - Do not include refresh status, manifest-maintenance notes, selected-pages bookkeeping, or any other workflow narration in `report.md`.
    - Include operational notes only if they materially affected audit quality, such as an unrefreshable repo, missing source files, or a manifest ambiguity that changes confidence in the findings.
 9. Complete each run:
    - `uv run python scripts/run_audit.py complete --run-id <run_id>`
+   - Completion publishes the pending directory to `artifacts/runs/<run_id>` and updates `artifacts/latest_run.json`.
+   - Only completed runs with `report.md` should appear under `artifacts/runs/`.
 10. Return a concise markdown summary suitable for the Codex inbox item.
 
 ## Manifest maintenance rules

--- a/workflows/docs-audit/scripts/run_audit.py
+++ b/workflows/docs-audit/scripts/run_audit.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CONFIG = ROOT / "config.toml"
+DEFAULT_PENDING_ARTIFACTS_DIR = "artifacts/pending"
 EXCERPT_LIMIT = 12
 SYMBOL_PATTERNS = [
     re.compile(r"\b(pub\s+enum|pub\s+struct|pub\s+fn|async\s+fn|fn\s+test_|def\s+test_|test\(|describe\()"),
@@ -272,6 +273,14 @@ def write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def completed_runs_dir(config: dict[str, Any]) -> Path:
+    return ROOT / config["paths"]["artifacts_dir"]
+
+
+def pending_runs_dir(config: dict[str, Any]) -> Path:
+    return ROOT / config["paths"].get("pending_artifacts_dir", DEFAULT_PENDING_ARTIFACTS_DIR)
+
+
 def load_state(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"version": 1, "areas": {}}
@@ -318,7 +327,9 @@ def refresh_latest_run_file(latest_run_file: Path, runs_dir: Path, deleted_run_i
     latest = json.loads(latest_run_file.read_text(encoding="utf-8"))
     if latest.get("run_id") not in deleted_run_ids:
         return
-    remaining_runs = sorted(path for path in runs_dir.iterdir() if path.is_dir())
+    remaining_runs = sorted(
+        path for path in runs_dir.iterdir() if path.is_dir() and (path / "report.md").exists()
+    )
     if not remaining_runs:
         latest_run_file.unlink()
         return
@@ -332,7 +343,7 @@ def refresh_latest_run_file(latest_run_file: Path, runs_dir: Path, deleted_run_i
     if metadata_path.exists():
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
         replacement["area"] = metadata.get("area", "")
-        replacement["completed_at"] = metadata.get("created_at", "")
+        replacement["completed_at"] = metadata.get("completed_at", metadata.get("created_at", ""))
     if report_path.exists():
         replacement["report_path"] = str(report_path)
     write_json(latest_run_file, replacement)
@@ -434,7 +445,7 @@ def prepare(args: argparse.Namespace) -> int:
     previous_fingerprints = area_state.get("page_fingerprints", {})
     rotation_index = int(area_state.get("rotation_index", 0))
     run_id = utc_run_id()
-    run_dir = ROOT / config["paths"]["artifacts_dir"] / run_id
+    run_dir = pending_runs_dir(config) / run_id
     page_dir = run_dir / "page_bundles"
     llm_dir = run_dir / "llm_outputs"
     ensure_dir(page_dir)
@@ -468,9 +479,11 @@ def prepare(args: argparse.Namespace) -> int:
     }
     write_json(run_dir / "selected_pages.json", selected_payload)
 
+    created_at = datetime.now(timezone.utc).isoformat()
     metadata = {
         "run_id": run_id,
         "area": args.area,
+        "status": "prepared",
         "manifest": {
             "name": manifest.name,
             "description": manifest.description,
@@ -485,13 +498,16 @@ def prepare(args: argparse.Namespace) -> int:
         },
         "selected_pages": selected_pages,
         "changed_pages": changed_pages,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": created_at,
+        "prepared_at": created_at,
     }
     write_json(run_dir / "metadata.json", metadata)
 
     summary = {
         "run_id": run_id,
         "run_dir": str(run_dir),
+        "final_run_dir": str(completed_runs_dir(config) / run_id),
+        "pending": True,
         "selected_pages": selected_pages,
         "changed_pages": changed_pages,
     }
@@ -503,10 +519,16 @@ def complete(args: argparse.Namespace) -> int:
     config = load_config(Path(args.config))
     state_path = ROOT / config["paths"]["state_file"]
     latest_run_file = ROOT / config["paths"]["latest_run_file"]
-    run_dir = ROOT / config["paths"]["artifacts_dir"] / args.run_id
+    final_run_dir = completed_runs_dir(config) / args.run_id
+    pending_run_dir = pending_runs_dir(config) / args.run_id
+    run_dir = pending_run_dir if pending_run_dir.exists() else final_run_dir
     metadata_path = run_dir / "metadata.json"
     selected_path = run_dir / "selected_pages.json"
     report_path = run_dir / "report.md"
+    if not run_dir.exists():
+        raise SystemExit(
+            f"Missing prepared run {args.run_id}. Looked in {pending_run_dir} and {final_run_dir}"
+        )
     if not metadata_path.exists():
         raise SystemExit(f"Missing metadata.json for run {args.run_id}")
     if not selected_path.exists():
@@ -516,6 +538,20 @@ def complete(args: argparse.Namespace) -> int:
 
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     selected = json.loads(selected_path.read_text(encoding="utf-8"))
+    completed_at = datetime.now(timezone.utc).isoformat()
+    if run_dir == pending_run_dir:
+        if final_run_dir.exists():
+            raise SystemExit(f"Cannot publish run {args.run_id}: {final_run_dir} already exists")
+        ensure_dir(final_run_dir.parent)
+        shutil.move(str(pending_run_dir), str(final_run_dir))
+        run_dir = final_run_dir
+        metadata_path = run_dir / "metadata.json"
+        report_path = run_dir / "report.md"
+
+    metadata["status"] = "completed"
+    metadata["completed_at"] = completed_at
+    write_json(metadata_path, metadata)
+
     state = load_state(state_path)
     areas = state.setdefault("areas", {})
     area_state = areas.setdefault(metadata["area"], {})
@@ -525,7 +561,7 @@ def complete(args: argparse.Namespace) -> int:
     area_state["last_selected_pages"] = selected["selected_pages"]
     area_state["last_changed_pages"] = selected["changed_pages"]
     area_state["last_report_path"] = str(report_path)
-    area_state["completed_at"] = datetime.now(timezone.utc).isoformat()
+    area_state["completed_at"] = completed_at
     write_json(state_path, state)
     write_json(
         latest_run_file,
@@ -534,7 +570,7 @@ def complete(args: argparse.Namespace) -> int:
             "area": metadata["area"],
             "run_dir": str(run_dir),
             "report_path": str(report_path),
-            "completed_at": area_state["completed_at"],
+            "completed_at": completed_at,
         },
     )
     print(json.dumps({"completed": True, "run_id": args.run_id, "run_dir": str(run_dir)}, indent=2))
@@ -543,7 +579,7 @@ def complete(args: argparse.Namespace) -> int:
 
 def cleanup(args: argparse.Namespace) -> int:
     config = load_config(Path(args.config))
-    runs_dir = ROOT / config["paths"]["artifacts_dir"]
+    runs_dir = completed_runs_dir(config)
     latest_run_file = ROOT / config["paths"]["latest_run_file"]
     state_path = ROOT / config["paths"]["state_file"]
     if not runs_dir.exists():

--- a/workflows/docs-audit/skills/area-manifest-authoring/SKILL.md
+++ b/workflows/docs-audit/skills/area-manifest-authoring/SKILL.md
@@ -7,7 +7,7 @@ description: Use when creating or updating a docs audit area manifest in this re
 
 Use this skill to create or refresh `manifests/<area>.toml` for the docs-audit workspace.
 
-This repo does not vendor the watched repos. The job is to map a docs domain to compact, user-facing evidence in the external repos.
+This repo does not vendor the watched repos. The job is to map a docs domain to compact, user-facing evidence in the external repos. Use the description from existing manifests as a starting point.
 
 ## Read first
 
@@ -133,9 +133,14 @@ uv run python scripts/run_audit.py prepare --area <area>
 
 Inspect:
 
-- `artifacts/runs/<run_id>/metadata.json`
-- `artifacts/runs/<run_id>/selected_pages.json`
-- `artifacts/runs/<run_id>/page_bundles/*.json`
+- the `run_dir` printed by `prepare` (normally `artifacts/pending/<run_id>`)
+- `<run_dir>/metadata.json`
+- `<run_dir>/selected_pages.json`
+- `<run_dir>/page_bundles/*.json`
+
+Manifest validation is intentionally a pending run. Do not write `report.md` or call `complete`
+unless you are running the full docs audit. Completed runs with reports are the only directories
+that should be published under `artifacts/runs/`.
 
 If the bundles are noisy, tighten:
 


### PR DESCRIPTION
## Reranking docs gaps — fixes from audit run `20260504T152409Z`

Addresses the six gaps flagged in the docs-audit report for the reranking area, cross-checked against the `lancedb` source repo.

### Overview page
- **Multi-vector example:** added `.with_row_id(True)` on each search call and a warning explaining that `deduplicate=True` raises `ValueError` without `_rowid` (which is opt-in, so this is the default failure mode). Also calls out that `RRFReranker.rerank_multivector(...)` requires `_rowid` regardless of the flag.
- **SDK coverage:** added a note after the Supported Rerankers table clarifying that `CohereReranker` / `CrossEncoderReranker` / `ColbertReranker` are Python-only — TypeScript and Rust currently expose only the generic `Reranker` interface and `RRFReranker`.

### Custom rerankers page
- **Intro:** rewritten to explain which methods to override (`rerank_hybrid()` required; `rerank_vector()` / `rerank_fts()` optional) and to flag that the base class raises `NotImplementedError` if you call rerank on a single-modality path you didn't override.
- **Return-shape contract:** added a short paragraph to the Interface section stating the actual rule — your reranker must attach a `_relevance_score` column sorted descending, otherwise LanceDB rejects the table or `.limit(...)` returns rows in the wrong order.

### Evaluation page
- **Score-based bullet:** reframed so RRF is mentioned as the default and linear combination is one option, rather than implying linear combination is the only score-based path.
- **Default reranker:** added an info callout noting that hybrid `.rerank()` defaults to `RRFReranker()`.
- **`normalize` parameter:** added a tip documenting `normalize="score"` (default) vs `normalize="rank"` and why it matters when evaluating score-based rerankers.

No test files changed, so no snippet regeneration was done as a result.
