### PR TITLE
Update storage docs based on gaps identified

### DIFF
--- a/docs/snippets/search.mdx
+++ b/docs/snippets/search.mdx
@@ -8,9 +8,9 @@ export const PyBasicHybridSearch = "data = [\n    {\"text\": \"rebel spaceships 
 
 export const PyBasicHybridSearchAsync = "uri = \"data/sample-lancedb\"\nasync_db = await lancedb.connect_async(uri)\ndata = [\n    {\"text\": \"rebel spaceships striking from a hidden base\"},\n    {\"text\": \"have won their first victory against the evil Galactic Empire\"},\n    {\"text\": \"during the battle rebel spies managed to steal secret plans\"},\n    {\"text\": \"to the Empire's ultimate weapon the Death Star\"},\n]\nasync_tbl = await async_db.create_table(\"documents_async\", schema=Documents)\n# ingest docs with auto-vectorization\nawait async_tbl.add(data)\n# Create a fts index before the hybrid search\nawait async_tbl.create_index(\"text\", config=FTS())\ntext_query = \"flower moon\"\n# hybrid search with default re-ranker\nawait (await async_tbl.search(\"flower moon\", query_type=\"hybrid\")).to_pandas()\n";
 
-export const PyClassDefinition = "class Metadata(BaseModel):\n    source: str\n    timestamp: datetime\n\n\nclass Document(BaseModel):\n    content: str\n    meta: Metadata\n\n\nclass LanceSchema(LanceModel):\n    id: str\n    vector: Vector(1536)\n    payload: Document\n";
-
 export const PyClassDocuments = "class Documents(LanceModel):\n    vector: Vector(embeddings.ndims()) = embeddings.VectorField()\n    text: str = embeddings.SourceField()\n";
+
+export const PyClassDefinition = "class Metadata(BaseModel):\n    source: str\n    timestamp: datetime\n\n\nclass Document(BaseModel):\n    content: str\n    meta: Metadata\n\n\nclass LanceSchema(LanceModel):\n    id: str\n    vector: Vector(1536)\n    payload: Document\n";
 
 export const PyCreateTableAsyncWithNestedSchema = "# Let's add 100 sample rows to our dataset\ndata = [\n    LanceSchema(\n        id=f\"id{i}\",\n        vector=np.random.randn(1536),\n        payload=Document(\n            content=f\"document{i}\",\n            meta=Metadata(source=f\"source{i % 10}\", timestamp=datetime.now()),\n        ),\n    )\n    for i in range(100)\n]\n\nasync_tbl = await async_db.create_table(\n    \"documents_async\", data=data, mode=\"overwrite\"\n)\n";
 

--- a/docs/snippets/storage.mdx
+++ b/docs/snippets/storage.mdx
@@ -2,6 +2,8 @@
 
 export const PyStorageAzureAccount = "db = lancedb.connect(\n    \"az://my-container/my-database\",\n    storage_options={\n        \"account_name\": \"some-account\",\n        \"account_key\": \"some-key\",\n    },\n)\n";
 
+export const PyStorageAzureSas = "db = lancedb.connect(\n    \"az://my-container/my-database\",\n    storage_options={\n        \"azure_storage_account_name\": \"some-account\",\n        \"azure_storage_sas_token\": \"<sas-token>\",\n    },\n)\n";
+
 export const PyStorageConnectAzure = "db = lancedb.connect(\"az://bucket/path\")\n";
 
 export const PyStorageConnectGcs = "db = lancedb.connect(\"gs://bucket/path\")\n";
@@ -12,19 +14,23 @@ export const PyStorageConnectTimeout = "db = lancedb.connect(\n    \"s3://bucket
 
 export const PyStorageGcsServiceAccount = "db = lancedb.connect(\n    \"gs://my-bucket/my-database\",\n    storage_options={\n        \"service_account\": \"path/to/service-account.json\",\n    },\n)\n";
 
-export const PyStorageProviderRefresh = "class StsStorageOptionsProvider:\n    # LanceDB calls this method whenever credentials need refresh.\n    def fetch_storage_options(self) -> dict[str, str]:\n        # Replace this with your credential manager or STS call.\n        return {\n            \"region\": \"us-east-1\",\n            \"aws_access_key_id\": \"<temp-access-key-id>\",\n            \"aws_secret_access_key\": \"<temp-secret-access-key>\",\n            \"aws_session_token\": \"<temp-session-token>\",\n            \"expires_at_millis\": \"1735707600000\",\n            \"refresh_offset_millis\": \"120000\",\n        }\n\nprovider = StsStorageOptionsProvider()\ndb = lancedb.connect(\"s3://bucket/path\")\ntable = db.create_table(\n    \"table_with_temp_creds\",\n    [{\"id\": 1}],\n    storage_options_provider=provider,\n)\n";
-
 export const PyStorageS3Ddb = "db = lancedb.connect(\n    \"s3+ddb://bucket/path?ddbTableName=my-dynamodb-table\",\n)\n";
+
+export const PyStorageS3DdbLocal = "db = lancedb.connect(\n    \"s3+ddb://bucket/path?ddbTableName=my-dynamodb-table\",\n    storage_options={\n        \"endpoint\": \"http://localhost:4566\",\n        \"dynamodb_endpoint\": \"http://localhost:4566\",\n        \"allow_http\": \"true\",\n    },\n)\n";
 
 export const PyStorageS3Express = "db = lancedb.connect(\n    \"s3://my-bucket--use1-az4--x-s3/path\",\n    storage_options={\n        \"region\": \"us-east-1\",\n        \"s3_express\": \"true\",\n    },\n)\n";
 
 export const PyStorageS3Minio = "db = lancedb.connect(\n    \"s3://bucket/path\",\n    storage_options={\n        \"region\": \"us-east-1\",\n        \"endpoint\": \"http://minio:9000\",\n    },\n)\n";
+
+export const PyStorageS3SseKms = "db = lancedb.connect(\n    \"s3://bucket/path\",\n    storage_options={\n        \"aws_server_side_encryption\": \"aws:kms\",\n        \"aws_sse_kms_key_id\": \"<your-kms-key-id-or-arn>\",\n    },\n)\n";
 
 export const PyStorageTableTimeout = "table = db.create_table(\n    \"table\",\n    [{\"a\": 1, \"b\": 2}],\n    storage_options={\"timeout\": \"60s\"},\n)\n";
 
 export const PyStorageTigrisConnect = "db = lancedb.connect(\n    \"s3://your-bucket/path\",\n    storage_options={\n        \"endpoint\": \"https://t3.storage.dev\",\n        \"region\": \"auto\",\n    },\n)\n";
 
 export const TsStorageAzureAccount = "async function storageAzureAccount() {\n  const db = await lancedb.connect(\n    \"az://my-container/my-database\",\n    {\n      storageOptions: {\n        accountName: \"some-account\",\n        accountKey: \"some-key\",\n      },\n    },\n  );\n  return db;\n}\n";
+
+export const TsStorageAzureSas = "async function storageAzureSas() {\n  const db = await lancedb.connect(\n    \"az://my-container/my-database\",\n    {\n      storageOptions: {\n        azureStorageAccountName: \"some-account\",\n        azureStorageSasToken: \"<sas-token>\",\n      },\n    },\n  );\n  return db;\n}\n";
 
 export const TsStorageConnectAzure = "async function storageConnectAzure() {\n  const db = await lancedb.connect(\"az://bucket/path\");\n  return db;\n}\n";
 
@@ -38,9 +44,13 @@ export const TsStorageGcsServiceAccount = "async function storageGcsServiceAccou
 
 export const TsStorageS3Ddb = "async function storageS3Ddb() {\n  const db = await lancedb.connect(\n    \"s3+ddb://bucket/path?ddbTableName=my-dynamodb-table\",\n  );\n  return db;\n}\n";
 
+export const TsStorageS3DdbLocal = "async function storageS3DdbLocal() {\n  const db = await lancedb.connect(\n    \"s3+ddb://bucket/path?ddbTableName=my-dynamodb-table\",\n    {\n      storageOptions: {\n        endpoint: \"http://localhost:4566\",\n        dynamodbEndpoint: \"http://localhost:4566\",\n        allowHttp: \"true\",\n      },\n    },\n  );\n  return db;\n}\n";
+
 export const TsStorageS3Express = "async function storageS3Express() {\n  const db = await lancedb.connect(\n    \"s3://my-bucket--use1-az4--x-s3/path\",\n    {\n      storageOptions: {\n        region: \"us-east-1\",\n        s3Express: \"true\",\n      },\n    },\n  );\n  return db;\n}\n";
 
 export const TsStorageS3Minio = "async function storageS3Minio() {\n  const db = await lancedb.connect(\"s3://bucket/path\", {\n    storageOptions: {\n      region: \"us-east-1\",\n      endpoint: \"http://minio:9000\",\n    },\n  });\n  return db;\n}\n";
+
+export const TsStorageS3SseKms = "async function storageS3SseKms() {\n  const db = await lancedb.connect(\"s3://bucket/path\", {\n    storageOptions: {\n      awsServerSideEncryption: \"aws:kms\",\n      awsSseKmsKeyId: \"<your-kms-key-id-or-arn>\",\n    },\n  });\n  return db;\n}\n";
 
 export const TsStorageTableTimeout = "async function storageTableTimeout() {\n  const db = await lancedb.connect(\"s3://bucket/path\");\n  const table = await db.createTable(\n    \"table\",\n    [{ a: 1, b: 2 }],\n    { storageOptions: { timeout: \"60s\" } },\n  );\n  return table;\n}\n";
 

--- a/docs/storage/configuration.mdx
+++ b/docs/storage/configuration.mdx
@@ -6,59 +6,70 @@ icon: "wrench"
 ---
 import {
     PyStorageAzureAccount,
+    PyStorageAzureSas,
     PyStorageConnectAzure,
     PyStorageConnectGcs,
     PyStorageConnectS3,
     PyStorageConnectTimeout,
-    PyStorageProviderRefresh,
     PyStorageGcsServiceAccount,
     PyStorageS3Ddb,
+    PyStorageS3DdbLocal,
     PyStorageS3Express,
     PyStorageS3Minio,
+    PyStorageS3SseKms,
     PyStorageTableTimeout,
     PyStorageTigrisConnect,
     TsStorageAzureAccount,
+    TsStorageAzureSas,
     TsStorageConnectAzure,
     TsStorageConnectGcs,
     TsStorageConnectS3,
     TsStorageConnectTimeout,
     TsStorageGcsServiceAccount,
     TsStorageS3Ddb,
+    TsStorageS3DdbLocal,
     TsStorageS3Express,
     TsStorageS3Minio,
+    TsStorageS3SseKms,
     TsStorageTableTimeout,
     TsStorageTigrisConnect,
 } from '/snippets/storage.mdx';
 
 When using LanceDB OSS, you can choose where to store your data. The tradeoffs between storage options are covered in the [storage architecture guide](/storage). This page shows how to configure each backend.
 
+<Note>
+**LanceDB Enterprise storage configuration**
+
+In LanceDB Enterprise, you connect with `db://...` and the cluster owns the storage credentials, so `storage_options` are not passed at runtime. Cloud auth is set at deployment time. For federated databases, the namespace service vends per-request credentials automatically. See the [Enterprise quickstart](/enterprise/quickstart) and the [Azure deployment guide](/enterprise/deployment/azure) for the Enterprise flow.
+</Note>
+
 ## Object stores
 
 LanceDB supports AWS S3 (and compatible stores), Azure Blob Storage, and Google Cloud Storage. The URI scheme in your `connect` call selects the backend.
 
 <CodeGroup>
-    <CodeBlock language="Python" title="AWS S3" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageConnectS3}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="AWS S3" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageConnectS3}
     </CodeBlock>
 </CodeGroup>
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Google Cloud Storage" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageConnectGcs}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Google Cloud Storage" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageConnectGcs}
     </CodeBlock>
 </CodeGroup>
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Azure Blob Storage" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageConnectAzure}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Azure Blob Storage" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageConnectAzure}
     </CodeBlock>
 </CodeGroup>
@@ -68,37 +79,36 @@ LanceDB supports AWS S3 (and compatible stores), Azure Blob Storage, and Google 
 When running inside the target cloud with correct IAM bindings, LanceDB often needs no extra configuration. When running elsewhere, provide credentials via environment variables or `storage_options`.
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Set a request timeout" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageConnectTimeout}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Set a request timeout" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageConnectTimeout}
     </CodeBlock>
 </CodeGroup>
 
-<Info title="Storage option casing">
+<Info>
+**Storage option casing**
+
 Keys are case-insensitive. Use lowercase in `storage_options` and uppercase in environment variables.
 </Info>
 
-If you need the option to apply only to a specific table:
+Table-level `storage_options` inherit every key from the connection and override on a per-key basis. Pass them to `create_table` or `open_table` for options that should apply to a single table:
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Table-level storage options" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageTableTimeout}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Table-level storage options" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageTableTimeout}
     </CodeBlock>
 </CodeGroup>
 
-### Dynamic credentials with `StorageOptionsProvider` <Badge color="green">Python-only</Badge>  
-Use a storage options provider when credentials expire (for example, short-lived STS credentials). Pass any provider object that implements `fetch_storage_options()` with `storage_options_provider` on table operations such as `create_table` and `open_table`. In SDK versions that expose `StorageOptionsProvider`, you can subclass it directly.
+<Tip>
+**Inspect the effective options**
 
-If `fetch_storage_options()` returns `expires_at_millis`, LanceDB refreshes credentials before that timestamp. You can optionally set `refresh_offset_millis` (in milliseconds) to refresh earlier.
-
-<CodeBlock language="Python" title="Refresh cloud credentials automatically" icon="python">
-{PyStorageProviderRefresh}
-</CodeBlock>
+On `AsyncTable`, `await table.initial_storage_options()` returns the options the table was opened with, and `await table.latest_storage_options()` returns the current options after any provider-driven refresh. The deprecated `table.storage_options()` method will be removed in a future release.
+</Tip>
 
 #### General object store options
 
@@ -116,13 +126,15 @@ If `fetch_storage_options()` returns `expires_at_millis`, LanceDB refreshes cred
 | `client_max_retries` | Maximum retries for object-store client requests. |
 | `client_retry_timeout` | Total retry timeout (seconds) for object-store client requests. |
 
-<Info title="Option support varies by backend">
+<Info>
+**Option support varies by backend**
+
 These are commonly used options. Cloud-specific keys (for example `region`, `endpoint`, `service_account`, and Azure credential keys) are backend-dependent and can be provided in `storage_options` as needed.
 </Info>
 
 #### New table configuration
 
-These options control the Lance file format and features used when creating new tables. Pass them via `storage_options` at connection or table level.
+These options control the Lance file format and features used when creating new tables. Pass them via `storage_options` at connection or table level. They are evaluated only at table creation; setting them on an existing connection does not rewrite or alter tables that already exist.
 
 | Key | Values | Default | Description |
 | :-- | :-- | :-- | :-- |
@@ -168,7 +180,9 @@ const db = await lancedb.connect("s3://bucket/path", {
 ```
 </CodeGroup>
 
-<Warning title="Deprecated parameter">
+<Warning>
+**Deprecated parameter**
+
 The `data_storage_version` parameter on `create_table()` is deprecated. Use `new_table_data_storage_version` in `storage_options` instead.
 </Warning>
 
@@ -183,10 +197,10 @@ Minimum permissions usually include `s3:PutObject`, `s3:GetObject`, `s3:DeleteOb
 ### S3-compatible stores
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Connect to an S3-compatible endpoint" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageS3Minio}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Connect to an S3-compatible endpoint" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageS3Minio}
     </CodeBlock>
 </CodeGroup>
@@ -196,10 +210,10 @@ If the endpoint is `http://` (common in local development), also set `ALLOW_HTTP
 ### S3 Express
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Use an S3 Express One Zone bucket" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageS3Express}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Use an S3 Express One Zone bucket" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageS3Express}
     </CodeBlock>
 </CodeGroup>
@@ -211,19 +225,49 @@ Consult AWS networking requirements for S3 Express before enabling.
 S3 lacks atomic writes. To enable safe concurrent writers, use DynamoDB as a commit store by switching to the `s3+ddb` scheme and specifying the table name.
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Enable DynamoDB-backed commits" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageS3Ddb}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Enable DynamoDB-backed commits" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageS3Ddb}
     </CodeBlock>
 </CodeGroup>
 
 Create the DynamoDB table with hash key `base_uri` (string) and range key `version` (number). Small provisioned throughput (for example `ReadCapacityUnits=1`, `WriteCapacityUnits=1`) is sufficient for coordination.
 
-<Tip title="Clean up failed multipart uploads">
+The IAM principal that runs LanceDB needs `dynamodb:GetItem`, `dynamodb:PutItem`, and `dynamodb:DescribeTable` on the commit table, in addition to the usual S3 actions on the data bucket.
+
+To point at a non-AWS endpoint (for example LocalStack during local development), set `dynamodb_endpoint` alongside the regular S3 options:
+
+<CodeGroup>
+    <CodeBlock filename="Python" language="Python" icon="python">
+    {PyStorageS3DdbLocal}
+    </CodeBlock>
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
+    {TsStorageS3DdbLocal}
+    </CodeBlock>
+</CodeGroup>
+
+<Tip>
+**Clean up failed multipart uploads**
+
 LanceDB aborts multipart uploads on graceful shutdown, but crashes can leave incomplete uploads. Add an S3 lifecycle rule to delete in-progress uploads after a few days.
 </Tip>
+
+### Server-side encryption with KMS
+
+To encrypt at rest with an AWS KMS key, set `aws_server_side_encryption` to `aws:kms` and `aws_sse_kms_key_id` to the key ID or ARN. The same options apply at connection or table level and combine with bucket-level default encryption.
+
+<CodeGroup>
+    <CodeBlock filename="Python" language="Python" icon="python">
+    {PyStorageS3SseKms}
+    </CodeBlock>
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
+    {TsStorageS3SseKms}
+    </CodeBlock>
+</CodeGroup>
+
+The IAM principal needs `kms:Encrypt`, `kms:Decrypt`, and `kms:GenerateDataKey` on the configured KMS key.
 
 ## Google Cloud Storage
 
@@ -232,10 +276,10 @@ LanceDB aborts multipart uploads on graceful shutdown, but crashes can leave inc
 Provide credentials via `GOOGLE_SERVICE_ACCOUNT` (path to JSON) or include the path in `storage_options`. GCS defaults to HTTP/1; set `HTTP1_ONLY=false` if you need HTTP/2.
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Connect with a service account" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageGcsServiceAccount}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Connect with a service account" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageGcsServiceAccount}
     </CodeBlock>
 </CodeGroup>
@@ -247,15 +291,26 @@ Provide credentials via `GOOGLE_SERVICE_ACCOUNT` (path to JSON) or include the p
 Set `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY` as environment variables, or pass them via `storage_options`.
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Connect to Azure Blob Storage" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageAzureAccount}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Connect to Azure Blob Storage" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageAzureAccount}
     </CodeBlock>
 </CodeGroup>
 
-Other supported keys include service principal credentials (`azure_client_id`, `azure_client_secret`, `azure_tenant_id`), SAS tokens, managed identities, and custom endpoints.
+For SAS-token auth, set `azure_storage_account_name` and `azure_storage_sas_token`:
+
+<CodeGroup>
+    <CodeBlock filename="Python" language="Python" icon="python">
+    {PyStorageAzureSas}
+    </CodeBlock>
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
+    {TsStorageAzureSas}
+    </CodeBlock>
+</CodeGroup>
+
+Other supported keys include service principal credentials (`azure_client_id`, `azure_client_secret`, `azure_tenant_id`), managed identities, and custom endpoints.
 
 ## Tigris Object Storage
 
@@ -264,10 +319,10 @@ Other supported keys include service principal credentials (`azure_client_id`, `
 Tigris exposes an S3-compatible API. Configure the endpoint and region:
 
 <CodeGroup>
-    <CodeBlock language="Python" title="Connect to Tigris Object Storage" icon="python">
+    <CodeBlock filename="Python" language="Python" icon="python">
     {PyStorageTigrisConnect}
     </CodeBlock>
-    <CodeBlock language="TypeScript" title="Connect to Tigris Object Storage" icon="square-js">
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
     {TsStorageTigrisConnect}
     </CodeBlock>
 </CodeGroup>

--- a/docs/storage/index.mdx
+++ b/docs/storage/index.mdx
@@ -33,6 +33,12 @@ Below is a high-level comparison ordered from lowest cost to lowest latency.
 
 LanceDB separates storage and compute and writes immutable fragments, making it a strong fit for stateless, horizontally scalable deployments.
 
+<Note>
+**Concurrent writers on S3**
+
+Plain S3 lacks atomic writes, so multiple writers against the same table need an external commit coordinator. LanceDB ships a DynamoDB-backed coordinator behind the `s3+ddb://` URI scheme — see [DynamoDB commit store for concurrent writes](/storage/configuration#dynamodb-commit-store-for-concurrent-writes). Bucket-level [server-side encryption with KMS](/storage/configuration#server-side-encryption-with-kms) and [S3 Express One Zone](/storage/configuration#s3-express) are also supported on this tier.
+</Note>
+
 ### 2. File storage (EFS / GCS Filestore / Azure File)
 
 - **Latency**: Better than object storage; p95 under ~&lt;100ms is typical.
@@ -64,4 +70,12 @@ Keep a copy of data in object storage for disaster recovery. If zero downtime is
 - **Reliability/Availability**: Data is tied to the instance; backups must be rigorous.
 
 Use local disk only when you need extremely low latency and are comfortable owning the operational overhead.
+
+## File-format choices that interact with the backend
+
+A few `storage_options` keys shape new tables in ways that depend on the backend you picked above. They are documented in full on the [configuration page](/storage/configuration#new-table-configuration); the architecture-level summary is:
+
+- `new_table_enable_v2_manifest_paths` matters most on object stores, where opening a table with many versions is dominated by listing cost. Leave it off for backward compatibility with clients older than LanceDB 0.10.0.
+- `new_table_enable_stable_row_ids` keeps row IDs stable across compaction, delete, and merge. The choice is independent of the backend but affects any system that joins on row ID.
+- `new_table_data_storage_version` selects the on-disk format. The default `stable` is recommended for all new tables; pick `legacy` only when older readers must keep working.
 

--- a/tests/py/test_storage.py
+++ b/tests/py/test_storage.py
@@ -22,7 +22,6 @@ class DummyConnection:
         name: str,
         data,
         storage_options: dict | None = None,
-        storage_options_provider=None,
     ):
         table = DummyTable(name, storage_options=storage_options)
         self.created_tables.append(table)
@@ -76,6 +75,37 @@ def test_storage_snippets(fake_connect):
     )
     # --8<-- [end:storage_s3_ddb]
 
+    # --8<-- [start:storage_s3_ddb_local]
+    db = lancedb.connect(
+        "s3+ddb://bucket/path?ddbTableName=my-dynamodb-table",
+        storage_options={
+            "endpoint": "http://localhost:4566",
+            "dynamodb_endpoint": "http://localhost:4566",
+            "allow_http": "true",
+        },
+    )
+    # --8<-- [end:storage_s3_ddb_local]
+
+    # --8<-- [start:storage_s3_sse_kms]
+    db = lancedb.connect(
+        "s3://bucket/path",
+        storage_options={
+            "aws_server_side_encryption": "aws:kms",
+            "aws_sse_kms_key_id": "<your-kms-key-id-or-arn>",
+        },
+    )
+    # --8<-- [end:storage_s3_sse_kms]
+
+    # --8<-- [start:storage_azure_sas]
+    db = lancedb.connect(
+        "az://my-container/my-database",
+        storage_options={
+            "azure_storage_account_name": "some-account",
+            "azure_storage_sas_token": "<sas-token>",
+        },
+    )
+    # --8<-- [end:storage_azure_sas]
+
     # --8<-- [start:storage_s3_minio]
     db = lancedb.connect(
         "s3://bucket/path",
@@ -125,30 +155,7 @@ def test_storage_snippets(fake_connect):
     )
     # --8<-- [end:storage_tigris_connect]
 
-    # --8<-- [start:storage_provider_refresh]
-    class StsStorageOptionsProvider:
-        # LanceDB calls this method whenever credentials need refresh.
-        def fetch_storage_options(self) -> dict[str, str]:
-            # Replace this with your credential manager or STS call.
-            return {
-                "region": "us-east-1",
-                "aws_access_key_id": "<temp-access-key-id>",
-                "aws_secret_access_key": "<temp-secret-access-key>",
-                "aws_session_token": "<temp-session-token>",
-                "expires_at_millis": "1735707600000",
-                "refresh_offset_millis": "120000",
-            }
-
-    provider = StsStorageOptionsProvider()
-    db = lancedb.connect("s3://bucket/path")
-    table = db.create_table(
-        "table_with_temp_creds",
-        [{"id": 1}],
-        storage_options_provider=provider,
-    )
-    # --8<-- [end:storage_provider_refresh]
-
-    assert len(fake_connect) == 11
+    assert len(fake_connect) == 13
     assert all(
         conn.uri.startswith(("s3://", "gs://", "az://", "s3+ddb://"))
         for conn in fake_connect

--- a/tests/ts/storage.test.ts
+++ b/tests/ts/storage.test.ts
@@ -54,6 +54,49 @@ async function storageS3Ddb() {
 }
 // --8<-- [end:storage_s3_ddb]
 
+// --8<-- [start:storage_s3_ddb_local]
+async function storageS3DdbLocal() {
+  const db = await lancedb.connect(
+    "s3+ddb://bucket/path?ddbTableName=my-dynamodb-table",
+    {
+      storageOptions: {
+        endpoint: "http://localhost:4566",
+        dynamodbEndpoint: "http://localhost:4566",
+        allowHttp: "true",
+      },
+    },
+  );
+  return db;
+}
+// --8<-- [end:storage_s3_ddb_local]
+
+// --8<-- [start:storage_s3_sse_kms]
+async function storageS3SseKms() {
+  const db = await lancedb.connect("s3://bucket/path", {
+    storageOptions: {
+      awsServerSideEncryption: "aws:kms",
+      awsSseKmsKeyId: "<your-kms-key-id-or-arn>",
+    },
+  });
+  return db;
+}
+// --8<-- [end:storage_s3_sse_kms]
+
+// --8<-- [start:storage_azure_sas]
+async function storageAzureSas() {
+  const db = await lancedb.connect(
+    "az://my-container/my-database",
+    {
+      storageOptions: {
+        azureStorageAccountName: "some-account",
+        azureStorageSasToken: "<sas-token>",
+      },
+    },
+  );
+  return db;
+}
+// --8<-- [end:storage_azure_sas]
+
 // --8<-- [start:storage_s3_minio]
 async function storageS3Minio() {
   const db = await lancedb.connect("s3://bucket/path", {
@@ -132,10 +175,13 @@ test("storage ts snippets compile", async () => {
   expect(storageConnectTimeout).toBeDefined();
   expect(storageTableTimeout).toBeDefined();
   expect(storageS3Ddb).toBeDefined();
+  expect(storageS3DdbLocal).toBeDefined();
   expect(storageS3Minio).toBeDefined();
   expect(storageS3Express).toBeDefined();
+  expect(storageS3SseKms).toBeDefined();
   expect(storageGcsServiceAccount).toBeDefined();
   expect(storageAzureAccount).toBeDefined();
+  expect(storageAzureSas).toBeDefined();
   expect(storageTigrisConnect).toBeDefined();
 });
 

--- a/workflows/docs-audit/manifests/storage.toml
+++ b/workflows/docs-audit/manifests/storage.toml
@@ -1,0 +1,101 @@
+name = "storage"
+description = "Audit the storage docs against user-facing evidence from lancedb, docs snippets/tests, and sophon."
+docs_repo = "docs"
+rotation_unit = "page"
+keywords = [
+  "storage",
+  "object store",
+  "S3",
+  "GCS",
+  "Azure Blob",
+  "MinIO",
+  "Tigris",
+  "storage_options",
+  "storageOptions",
+  "StorageOptionsProvider",
+  "DynamoDB",
+  "s3+ddb",
+  "S3 Express",
+  "new_table_data_storage_version",
+  "new_table_enable_v2_manifest_paths",
+  "new_table_enable_stable_row_ids",
+  "stable row IDs",
+  "v2 manifest paths",
+  "credential vending",
+]
+
+[[pages]]
+id = "overview"
+title = "Storage Architecture in LanceDB"
+path = "docs/storage/index.mdx"
+keywords = ["storage backend", "object storage", "file storage", "block storage", "local storage", "latency", "scalability", "cost", "reliability"]
+
+[[pages]]
+id = "configuration"
+title = "Configuring Cloud Storage in LanceDB"
+path = "docs/storage/configuration.mdx"
+keywords = ["S3", "GCS", "Azure Blob", "storage_options", "StorageOptionsProvider", "S3 Express", "DynamoDB", "MinIO", "Tigris", "new table configuration"]
+
+[[sources]]
+id = "docs-storage-snippets-tests"
+repo = "docs"
+kind = "snippets_and_tests"
+applies_to = ["configuration"]
+paths = [
+  "docs/snippets/storage.mdx",
+  "tests/py/test_storage.py",
+  "tests/ts/storage.test.ts",
+]
+extract_keywords = ["storage_options", "storageOptions", "StorageOptionsProvider", "fetch_storage_options", "expires_at_millis", "s3+ddb", "ddbTableName", "s3_express", "allow_http"]
+
+[[sources]]
+id = "lancedb-storage-public-apis"
+repo = "lancedb"
+kind = "public_api_doc_comments"
+applies_to = ["configuration"]
+paths = [
+  "python/python/lancedb/db.py",
+  "nodejs/lancedb/index.ts",
+  "nodejs/lancedb/connection.ts",
+  "rust/lancedb/src/connection.rs",
+  "rust/lancedb/src/database/listing.rs",
+  "rust/lancedb/src/table.rs",
+]
+extract_keywords = ["storage_options", "storageOptions", "storage_option", "StorageOptionsProvider", "new_table_data_storage_version", "new_table_enable_v2_manifest_paths", "new_table_enable_stable_row_ids", "initial_storage_options", "latest_storage_options"]
+
+[[sources]]
+id = "lancedb-object-store-tests"
+repo = "lancedb"
+kind = "object_store_integration_tests"
+applies_to = ["overview", "configuration"]
+paths = [
+  "python/python/tests/test_s3.py",
+  "nodejs/__test__/s3_integration.test.ts",
+  "rust/lancedb/tests/object_store_test.rs",
+]
+extract_keywords = ["S3", "DynamoDB", "s3+ddb", "ddbTableName", "concurrent", "KMS", "server side encryption", "storage_options", "allow_http", "dynamodb_endpoint"]
+
+[[sources]]
+id = "sophon-enterprise-storage-config"
+repo = "sophon"
+kind = "enterprise_config"
+applies_to = ["overview", "configuration"]
+paths = [
+  "helm/lancedb/values.yaml",
+  "helm/lancedb/configs/query-node/base.toml",
+]
+extract_keywords = ["rootUri", "externalManifestTable", "useS3Express", "cache_uri", "index_cache", "metadata_cache", "diskCache", "storageClassName", "useV2ManifestPaths"]
+
+[[sources]]
+id = "sophon-federated-storage-vending"
+repo = "sophon"
+kind = "enterprise_api_and_integration"
+applies_to = ["configuration"]
+paths = [
+  "src/rust/phalanx/openapi.yml",
+  "src/rust/phalanx/src/rest/table/table_utils.rs",
+  "src/rust/phalanx/configs/local-dir-ns-s3.toml",
+  "src/rust/phalanx/configs/local-dir-ns-azure.toml",
+  "src/lancedb_integtest/tools/verify_azure_credential_vending.py",
+]
+extract_keywords = ["storage_options", "credential vending", "vend_credentials", "expires_at_millis", "x-azure-storage-account-name", "azure_storage_account_name", "azure_storage_sas_token", "storage.allow_http", "federated_dbs"]


### PR DESCRIPTION
Address findings from the storage docs-gap audit and clarify OSS vs Enterprise scope.

### Architecture page

- Called out that plain S3 is single-writer-safe and concurrent writers need the DynamoDB commit store, with deeplinks to the relevant configuration sections.
- Added a "File-format choices that interact with the backend" section explaining how `new_table_enable_v2_manifest_paths`, `new_table_enable_stable_row_ids`, and `new_table_data_storage_version` map onto backend choice.

### Configuration page

- Added an Enterprise scoping note up top: this page is OSS-only; in Enterprise the cluster owns storage credentials, and federated databases use namespace-driven credential vending. Links out to the Enterprise quickstart and Azure deployment guide.
- Made connection-vs-table `storage_options` override semantics explicit ("inherit from connection, override per key").
- Documented the `initial_storage_options()` / `latest_storage_options()` accessors on `AsyncTable` and the deprecation of `storage_options()`.
- Noted that the `new_table_*` options are evaluated only at table creation and do not rewrite existing tables.
- Extended the DynamoDB section with required IAM actions and a `dynamodb_endpoint` example for LocalStack-style local dev.
- New "Server-side encryption with KMS" section covering `aws_server_side_encryption` / `aws_sse_kms_key_id` and the required KMS IAM actions.
- Documented the actual Azure SAS-token keys (`azure_storage_account_name`, `azure_storage_sas_token`) with a snippet, instead of mentioning "SAS tokens" generically.
- Removed the `StorageOptionsProvider` "Python-only" section. Cross-checking against `lancedb` confirmed `storage_options_provider=` is not part of the Python public API; the only path is `namespace_client=`, which belongs in dedicated namespace docs rather than a half-baked replacement here.

### Snippets / tests

- New runnable test snippets for the local DynamoDB endpoint, SSE-KMS, and Azure SAS examples; regenerated MDX exports.
- Removed the broken provider snippet (and its now-unused mock parameter).