### PR TITLE
docs(reranking): showcase RRFReranker and correct RRF query-type docs

### DIFF
--- a/docs/integrations/reranking/rrf.mdx
+++ b/docs/integrations/reranking/rrf.mdx
@@ -9,10 +9,18 @@ import { PyRerankingRrfUsage } from '/snippets/integrations.mdx';
 
 # Reciprocal Rank Fusion Reranker
 
-This is the default reranker used by LanceDB hybrid search. Reciprocal Rank Fusion (RRF) is an algorithm that evaluates the search scores by leveraging the positions/rank of the documents. The implementation follows this [paper](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf).
+**Reciprocal Rank Fusion (RRF)** is a model-free way to merge several ranked result lists into a
+single ordering. Rather than comparing raw similarity scores (which aren't directly comparable
+across, say, a vector search and a full-text search), RRF looks only at each document's *rank
+position* in each list. It scores every document with the formula `1 / (rank + K)`, sums those
+contributions across the lists, and re-sorts by the total. Documents that rank highly in more than
+one search rise to the top. Because there's no model to load or call, it's fast and cheap, which is
+why it's the default reranker for LanceDB hybrid search. The implementation follows the
+[Cormack et al. paper](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf).
 
-
-> **Note:** Supported query type – Hybrid search.
+> **Supported query types:** hybrid search and [multi-vector reranking](/reranking#multi-vector-reranking).
+> Because RRF fuses two or more ranked lists, it can't rerank a single vector or full-text result set
+> on its own. Calling `rerank_vector` or `rerank_fts` on an `RRFReranker` raises `NotImplementedError`.
 
 
 <CodeGroup>
@@ -28,6 +36,14 @@ Accepted Arguments
 | `K` | `int` | `60` | A constant used in the RRF formula (default is 60). Experiments indicate that k = 60 was near-optimal, but that the choice is not critical. |
 | `return_score` | `str` | `"relevance"` | Options are "relevance" or "all". The type of score to return. If "relevance", will return only the `_relevance_score`. If "all", will return all scores from the vector and FTS search along with the relevance score. |
 
+
+## Multi-vector reranking
+
+`RRFReranker` can also fuse the results of several vector searches with `rerank_multivector`, applying
+the same rank-fusion algorithm across more than two lists. Every input result set must include the
+`_rowid` column, so add `.with_row_id(True)` to each `table.search(...)` call before reranking,
+otherwise the call raises a `ValueError`. See [multi-vector reranking](/reranking#multi-vector-reranking)
+for a full example.
 
 ## Supported Scores for each query type
 You can specify the type of scores you want the reranker to return. The following are the supported scores for each query type:

--- a/docs/reranking/index.mdx
+++ b/docs/reranking/index.mdx
@@ -6,49 +6,73 @@ icon: "sort-amount-down"
 keywords: ["re-ranking", "reranker", "rerank"]
 ---
 
+import { PyRerankingLinearCombinationUsage, PyRerankingRrfUsage, PyRerankingCohereUsage } from '/snippets/integrations.mdx';
+
 Reranking is the process of re-ordering search results to improve relevance, often using a
 different model than the one used for the initial search. LanceDB has built-in support for reranking
 with models from Cohere, Sentence-Transformers, and more.
 
 ### Quickstart
 
-To use a reranker, you perform a search and then pass the results to the `rerank()` method.
+To use a reranker, you run a search and pass the results to the `rerank()` method. The examples below
+move from the simplest, model-free rerankers to a model-based one. Each is a complete, runnable script.
 
-Note that `CohereReranker()` requires the `cohere` package and either
-`COHERE_API_KEY` in the environment or an `api_key` argument.
+**1. Linear combination (simplest).** `LinearCombinationReranker` normalizes the vector and full-text
+scores and blends them with a single `weight` (default `0.7`, favoring the vector score). It runs no
+model, and reranks [hybrid search](/search/hybrid-search) results.
 
 <CodeGroup>
-```python Python icon="python"
-import lancedb
-from lancedb.rerank import CohereReranker
-
-db = lancedb.connect("/tmp/lancedb")
-table = db.open_table("my_table")
-
-query = "what is the capital of france"
-
-# Search with reranking
-reranker = CohereReranker()
-reranked_results = table.search(query).limit(10).rerank(reranker=reranker).to_df()
-```
+  <CodeBlock filename="Python" language="Python" icon="python">
+    {PyRerankingLinearCombinationUsage}
+  </CodeBlock>
 </CodeGroup>
+
+**2. Reciprocal Rank Fusion.** `RRFReranker` fuses results by rank position instead of raw score, so it
+sidesteps having to make vector and full-text scores comparable. It loads no model either, and it's the
+default reranker for hybrid search.
+
+<CodeGroup>
+  <CodeBlock filename="Python" language="Python" icon="python">
+    {PyRerankingRrfUsage}
+  </CodeBlock>
+</CodeGroup>
+
+**3. Cohere (model-based).** For higher relevance, a model-based reranker scores each result against the
+query with a trained model. `CohereReranker` works with vector, full-text, or hybrid search, and needs
+the `cohere` package plus either `COHERE_API_KEY` in the environment or an `api_key` argument.
+
+<CodeGroup>
+  <CodeBlock filename="Python" language="Python" icon="python">
+    {PyRerankingCohereUsage}
+  </CodeBlock>
+</CodeGroup>
+
+Reach for the model-free rerankers (`LinearCombinationReranker`, `RRFReranker`) when cost and latency
+matter most; reach for a model-based one like `CohereReranker` or `CrossEncoderReranker` when you need
+higher relevance and can afford to score every query and document pair with a model.
 
 ### Supported Rerankers
 
-LanceDB supports several rerankers out of the box. Here are a few examples:
+LanceDB supports the following rerankers out of the box. The first three are score-based and run no
+model; the rest are model-based. See the [integrations](/integrations/reranking) section for the
+arguments and details of each.
 
-| Reranker               | Default Model                          |
-| ---------------------- | -------------------------------------- |
-| `CohereReranker`       | `rerank-english-v2.0`                  |
-| `CrossEncoderReranker` | `cross-encoder/ms-marco-MiniLM-L-6-v2` |
-| `ColbertReranker`      | `colbert-ir/colbertv2.0`               |
+| Reranker                    | Default model                          |
+| --------------------------- | -------------------------------------- |
+| `RRFReranker`               | None (reciprocal rank fusion)          |
+| `LinearCombinationReranker` | None (weighted score blend)            |
+| `MRRReranker`               | None (weighted reciprocal rank)        |
+| `CohereReranker`            | `rerank-english-v3.0`                  |
+| `CrossEncoderReranker`      | `cross-encoder/ms-marco-TinyBERT-L-6`  |
+| `ColbertReranker`           | `colbert-ir/colbertv2.0`               |
+| `AnswerdotaiRerankers`      | `answerdotai/answerai-colbert-small-v1`|
+| `JinaReranker`              | `jina-reranker-v2-base-multilingual`   |
+| `OpenaiReranker`            | `gpt-4-turbo-preview`                  |
+| `VoyageAIReranker`          | No default (model name required)       |
 
-You can find more details about these and other rerankers in the [integrations](/integrations/reranking) section.
-
-Python also includes score-based rerankers such as `RRFReranker`, `LinearCombinationReranker`,
-and `MRRReranker`, plus provider rerankers for OpenAI, Jina, Voyage AI, Answer.AI, and Cohere.
-Provider rerankers usually need the provider package installed and either an API key argument or
-the provider-specific environment variable.
+The model-based rerankers need their provider package installed, and the hosted ones
+(`CohereReranker`, `JinaReranker`, `OpenaiReranker`, `VoyageAIReranker`) also need an API key, passed
+as an `api_key` argument or set in the provider-specific environment variable.
 
 Rerankers add `_relevance_score` and return rows ordered by descending relevance. Python rerankers
 accept `return_score="relevance"` or `return_score="all"` − use `"all"` when you want to keep the


### PR DESCRIPTION
## Summary

Fixes #256.

@paoloinverse pointed out that the docs don't showcase `RRFReranker`, even though it's the cheaper, model-free alternative to cross-encoders, and that the [`/integrations/reranking/rrf`](https://docs.lancedb.com/integrations/reranking/rrf) page is out of date about which query types it supports.

This PR addresses both, on two pages:

**`docs/reranking/index.mdx` (overview)**
- Quickstart now shows a progression from simplest/cheapest to model-based: `LinearCombinationReranker` → `RRFReranker` → `CohereReranker`. All three code blocks are imported from `tests/py/test_integrations.py`-backed snippets (no inline code).
- The "Supported Rerankers" table now lists **all** built-in rerankers, grouped score-based first, with their **actual** default models (corrected `CohereReranker` `v2.0`→`v3.0` and `CrossEncoderReranker` `MiniLM-L-6-v2`→`TinyBERT-L-6` from source; `VoyageAIReranker` has no default).
- Added cost/relevance guidance and fixed a stale import (`lancedb.rerank` → `lancedb.rerankers`).

**`docs/integrations/reranking/rrf.mdx`**
- Introduces Reciprocal Rank Fusion as a term (rank-position fusion via `1 / (rank + K)`, model-free) instead of assuming the reader knows it.
- Corrects the supported query types: **hybrid** and **multi-vector**. The `rerank_vector` / `rerank_fts` methods visible in `dir()` are inherited base stubs that raise `NotImplementedError` on `RRFReranker`, so they are *not* supported — this is the heart of the issue's confusion.
- Adds a multi-vector reranking section noting the `_rowid` requirement.

## Test plan
- [x] `make py` regenerates snippets with no drift (the new `{Py...}` imports resolve to existing exports)
- [x] `RUN_RERANKER_SNIPPETS=1 pytest -k "reranking_rrf_usage or reranking_linear_combination_usage"` → both PASS
- [x] `test_reranking_cohere_usage` skips locally (no `COHERE_API_KEY`); covered in CI
- [x] All reranker claims grounded in `lancedb/rerankers/` source (no fabricated APIs/defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)