### PR TITLE
chore(docs): sync OpenAPI spec

### DIFF
--- a/docs/api-reference/rest/openapi.yml
+++ b/docs/api-reference/rest/openapi.yml
@@ -608,6 +608,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
       - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/branch"
     post:
       tags:
         - Table
@@ -656,6 +657,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
       - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/branch"
       - $ref: "#/components/parameters/page_token"
       - $ref: "#/components/parameters/limit"
       - name: descending
@@ -938,6 +940,44 @@ paths:
         5XX:
           $ref: "#/components/responses/ServerErrorResponse"
 
+  /v1/table/{id}/update_field_metadata:
+    parameters:
+      - $ref: "#/components/parameters/id"
+      - $ref: "#/components/parameters/delimiter"
+    post:
+      tags:
+        - Table
+        - Metadata
+      summary: Update per-field metadata
+      operationId: UpdateFieldMetadata
+      description: |
+        Update the Arrow field (column) metadata for table `id`.
+
+        Each entry targets a field by `path` and merges the provided key-value
+        pairs into that field's existing metadata, or replaces it when `replace`
+        is true. A null metadata value deletes that key.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFieldMetadataRequest"
+      responses:
+        200:
+          $ref: "#/components/responses/UpdateFieldMetadataResponse"
+        400:
+          $ref: "#/components/responses/BadRequestErrorResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedErrorResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenErrorResponse"
+        404:
+          $ref: "#/components/responses/NotFoundErrorResponse"
+        503:
+          $ref: "#/components/responses/ServiceUnavailableErrorResponse"
+        5XX:
+          $ref: "#/components/responses/ServerErrorResponse"
+
   /v1/table/{id}/drop_columns:
     parameters:
       - $ref: "#/components/parameters/id"
@@ -1012,6 +1052,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
       - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/branch"
       - name: mode
         in: query
         description: |
@@ -1068,6 +1109,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
       - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/branch"
       - name: "on"
         in: query
         description: Column name to use for matching rows (required)
@@ -1779,6 +1821,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
       - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/branch"
       - name: index_name
         in: path
         description: Name of the index to drop
@@ -2039,6 +2082,120 @@ paths:
         5XX:
           $ref: "#/components/responses/ServerErrorResponse"
 
+  # Branch API
+
+  /v1/table/{id}/branches/list:
+    parameters:
+      - $ref: "#/components/parameters/id"
+      - $ref: "#/components/parameters/delimiter"
+      - $ref: "#/components/parameters/page_token"
+      - $ref: "#/components/parameters/limit"
+    post:
+      tags:
+        - Table
+        - Branch
+        - Metadata
+      summary: List all branches for a table
+      operationId: ListTableBranches
+      description: |
+        List all branches that have been created for table `id`.
+        Returns a map of branch names to their contents.
+
+        REST NAMESPACE ONLY
+        REST namespace does not use a request body for this operation.
+        The `ListTableBranchesRequest` information is passed in the following way:
+        - `id`: pass through path parameter of the same name
+        - `page_token`: pass through query parameter of the same name
+        - `limit`: pass through query parameter of the same name
+      responses:
+        200:
+          $ref: "#/components/responses/ListTableBranchesResponse"
+        400:
+          $ref: "#/components/responses/BadRequestErrorResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedErrorResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenErrorResponse"
+        404:
+          $ref: "#/components/responses/NotFoundErrorResponse"
+        503:
+          $ref: "#/components/responses/ServiceUnavailableErrorResponse"
+        5XX:
+          $ref: "#/components/responses/ServerErrorResponse"
+
+  /v1/table/{id}/branches/create:
+    parameters:
+      - $ref: "#/components/parameters/id"
+      - $ref: "#/components/parameters/delimiter"
+    post:
+      tags:
+        - Table
+        - Branch
+        - Metadata
+      summary: Create a new branch
+      operationId: CreateTableBranch
+      description: |
+        Create a new branch for table `id` starting from a source ref (another
+        branch and/or version), defaulting to the latest version of the main branch.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTableBranchRequest"
+      responses:
+        200:
+          $ref: "#/components/responses/CreateTableBranchResponse"
+        400:
+          $ref: "#/components/responses/BadRequestErrorResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedErrorResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenErrorResponse"
+        404:
+          $ref: "#/components/responses/NotFoundErrorResponse"
+        409:
+          $ref: "#/components/responses/ConflictErrorResponse"
+        503:
+          $ref: "#/components/responses/ServiceUnavailableErrorResponse"
+        5XX:
+          $ref: "#/components/responses/ServerErrorResponse"
+
+  /v1/table/{id}/branches/delete:
+    parameters:
+      - $ref: "#/components/parameters/id"
+      - $ref: "#/components/parameters/delimiter"
+    post:
+      tags:
+        - Table
+        - Branch
+        - Metadata
+      summary: Delete a branch
+      operationId: DeleteTableBranch
+      description: |
+        Delete an existing branch from table `id`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteTableBranchRequest"
+      responses:
+        200:
+          $ref: "#/components/responses/DeleteTableBranchResponse"
+        400:
+          $ref: "#/components/responses/BadRequestErrorResponse"
+        401:
+          $ref: "#/components/responses/UnauthorizedErrorResponse"
+        403:
+          $ref: "#/components/responses/ForbiddenErrorResponse"
+        404:
+          $ref: "#/components/responses/NotFoundErrorResponse"
+        503:
+          $ref: "#/components/responses/ServiceUnavailableErrorResponse"
+        5XX:
+          $ref: "#/components/responses/ServerErrorResponse"
+
   # Transaction API
 
   /v1/transaction/{id}/describe:
@@ -2129,6 +2286,17 @@ components:
       description: |
         An optional delimiter of the `string identifier`, following the Lance Namespace spec.
         When not specified, the `$` delimiter must be used.
+      in: query
+      required: false
+      schema:
+        type: string
+    branch:
+      name: branch
+      description: |
+        Optional branch to target. When not specified, the main branch is used.
+        Used by branch-scoped operations that cannot carry a `branch` field in
+        their request body (Arrow IPC stream and bodyless operations). Operations
+        with a JSON request body carry `branch` as a body field instead.
       in: query
       required: false
       schema:
@@ -2566,6 +2734,10 @@ components:
           type: integer
           format: int64
           minimum: 0
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         with_table_uri:
           description: |
             Whether to include the table URI in the response.
@@ -2724,6 +2896,10 @@ components:
           type: integer
           format: int64
           minimum: 0
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         predicate:
           description: |
             Optional SQL predicate to filter rows for counting
@@ -2750,6 +2926,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         mode:
           type: string
           description: |
@@ -2779,6 +2959,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         "on":
           description: Column name to use for matching rows (required)
           type: string
@@ -2853,6 +3037,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         predicate:
           type: string
           nullable: true
@@ -2916,6 +3104,10 @@ components:
           items:
             type: string
           description: The namespace identifier
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         predicate:
           type: string
           description: SQL predicate to filter rows for deletion
@@ -2946,6 +3138,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         bypass_vector_index:
           type: boolean
           description: Whether to bypass vector index
@@ -3060,6 +3256,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         column:
           type: string
           description: Name of the column to create index on
@@ -3141,6 +3341,10 @@ components:
           minimum: 0
           nullable: true
           description: Optional table version to list indexes from
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         page_token:
           $ref: "#/components/schemas/PageToken"
         limit:
@@ -3199,6 +3403,10 @@ components:
           minimum: 0
           nullable: true
           description: Optional table version to get stats for
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         index_name:
           type: string
           description: Name of the index
@@ -3826,6 +4034,11 @@ components:
           format: int64
           minimum: 0
           description: version number that the tag points to
+        branch:
+          type: string
+          description: |
+            Branch the tag's version lives on.
+            Absent when the tag points to the main branch.
 
     CreateTableTagRequest:
       type: object
@@ -3849,6 +4062,10 @@ components:
           format: int64
           minimum: 0
           description: Version number for the tag to point to
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
 
     CreateTableTagResponse:
       type: object
@@ -3905,6 +4122,10 @@ components:
           format: int64
           minimum: 0
           description: New version number for the tag to point to
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
 
     UpdateTableTagResponse:
       type: object
@@ -3965,6 +4186,132 @@ components:
           minimum: 0
           description: Size of the manifest file in bytes
 
+    BranchContents:
+      type: object
+      required:
+        - parentVersion
+        - createAt
+        - manifestSize
+      properties:
+        parentBranch:
+          type: string
+          description: |
+            Name of the branch this branch was created from.
+            Absent when the branch was created from the main branch.
+        parentVersion:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Version of the parent (branch or main) this branch was created from
+        createAt:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Unix timestamp (in seconds) when the branch was created
+        manifestSize:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Size of the branch's manifest file in bytes
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value metadata associated with the branch
+
+    CreateTableBranchRequest:
+      type: object
+      required:
+        - name
+      properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
+        id:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+          description: Name of the branch to create
+        from_branch:
+          type: string
+          description: |
+            Source branch to create the new branch from.
+            When omitted, the new branch is created from the main branch.
+        from_version:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Version of the source (branch or main) to create from.
+            When omitted, the latest version of the source is used.
+
+    CreateTableBranchResponse:
+      type: object
+      description: Response for create branch operation
+      properties:
+        transaction_id:
+          type: string
+          description: Optional transaction identifier
+
+    DeleteTableBranchRequest:
+      type: object
+      required:
+        - name
+      properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
+        id:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+          description: Name of the branch to delete
+
+    DeleteTableBranchResponse:
+      type: object
+      description: Response for delete branch operation
+      properties:
+        transaction_id:
+          type: string
+          description: Optional transaction identifier
+
+    ListTableBranchesRequest:
+      type: object
+      properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
+        id:
+          type: array
+          items:
+            type: string
+          description: The table identifier
+        page_token:
+          $ref: "#/components/schemas/PageToken"
+        limit:
+          $ref: "#/components/schemas/PageLimit"
+
+    ListTableBranchesResponse:
+      type: object
+      description: Response containing table branches
+      required:
+        - branches
+      properties:
+        branches:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/BranchContents"
+          description: Map of branch names to their contents
+        page_token:
+          $ref: "#/components/schemas/PageToken"
+
     RestoreTableRequest:
       type: object
       required:
@@ -3983,6 +4330,10 @@ components:
           format: int64
           minimum: 0
           description: Version to restore to
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
 
     RestoreTableResponse:
       type: object
@@ -4034,6 +4385,10 @@ components:
           items:
             type: string
           description: The table identifier
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         metadata:
           type: object
           additionalProperties:
@@ -4063,6 +4418,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         page_token:
           $ref: "#/components/schemas/PageToken"
         limit:
@@ -4112,6 +4471,10 @@ components:
           format: int64
           minimum: 0
           description: Version number to create
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         manifest_path:
           type: string
           description: Path to the manifest file for this version
@@ -4159,6 +4522,10 @@ components:
           format: int64
           minimum: 0
           description: Version number to describe
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
 
     DescribeTableVersionResponse:
       type: object
@@ -4187,6 +4554,10 @@ components:
           items:
             type: string
           description: The table identifier
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         ranges:
           type: array
           items:
@@ -4270,6 +4641,10 @@ components:
           format: int64
           minimum: 0
           description: Version number to create
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         manifest_path:
           type: string
           description: Path to the manifest file for this version
@@ -4451,6 +4826,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         query:
           $ref: "#/components/schemas/QueryTableRequest"
         verbose:
@@ -4481,6 +4860,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         bypass_vector_index:
           type: boolean
           description: Whether to bypass vector index
@@ -4602,6 +4985,10 @@ components:
           items:
             type: string
           description: Table identifier path (namespace + table name)
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         new_columns:
           type: array
           items:
@@ -4726,6 +5113,73 @@ components:
           description: The commit version associated with the operation
           minimum: 0
 
+    UpdateFieldMetadataRequest:
+      type: object
+      required:
+        - updates
+      properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
+        id:
+          type: array
+          items:
+            type: string
+          description: Table identifier path (namespace + table name)
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
+        updates:
+          type: array
+          items:
+            $ref: "#/components/schemas/UpdateFieldMetadataEntry"
+          description: List of per-field metadata updates to apply
+
+    UpdateFieldMetadataEntry:
+      type: object
+      required:
+        - path
+        - metadata
+      properties:
+        path:
+          type: string
+          description: Field (column) path whose metadata to update
+        metadata:
+          type: object
+          additionalProperties:
+            type:
+              - string
+              - "null"
+          description: |
+            Metadata key-value pairs to apply to the field. A null value
+            deletes that key.
+        replace:
+          type:
+            - boolean
+            - "null"
+          description: |
+            If true, replace the field's existing metadata entirely; otherwise
+            merge into it (optional, defaults to false).
+
+    UpdateFieldMetadataResponse:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: integer
+          format: int64
+          description: The commit version associated with the operation
+          minimum: 0
+        fields:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+          description: |
+            Resulting metadata for each updated field, keyed by field path.
+
     AlterTableAlterColumnsRequest:
       type: object
       required:
@@ -4738,6 +5192,10 @@ components:
           items:
             type: string
           description: Table identifier path (namespace + table name)
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         alterations:
           type: array
           items:
@@ -4852,6 +5310,10 @@ components:
           items:
             type: string
           description: Table identifier path (namespace + table name)
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         column:
           type: string
           description: Column name to backfill
@@ -5175,6 +5637,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         columns:
           type: array
           items:
@@ -5206,6 +5672,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
 
     GetTableStatsResponse:
       type: object
@@ -5306,6 +5776,10 @@ components:
           type: array
           items:
             type: string
+        branch:
+          type: string
+          description: |
+            Branch to target. When not specified, the main branch is used.
         index_name:
           type: string
           description: Name of the index to drop
@@ -5581,6 +6055,29 @@ components:
           schema:
             $ref: "#/components/schemas/UpdateTableTagResponse"
 
+    # Branch operation responses
+
+    ListTableBranchesResponse:
+      description: List of table branches
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListTableBranchesResponse"
+
+    CreateTableBranchResponse:
+      description: Create branch response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateTableBranchResponse"
+
+    DeleteTableBranchResponse:
+      description: Delete branch response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DeleteTableBranchResponse"
+
     # Table operation responses
 
     ListTableVersionsResponse:
@@ -5647,6 +6144,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/AlterTableAddColumnsResponse"
+
+    UpdateFieldMetadataResponse:
+      description: Field metadata update result
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpdateFieldMetadataResponse"
 
     AlterTableAlterColumnsResponse:
       description: Alter columns operation result


### PR DESCRIPTION
Syncs `docs/api-reference/rest/openapi.yml` from `lance-format/lance-namespace` (`docs/src/rest.yaml`).