### PR TITLE
[codex] fill docs audit gaps

### DIFF
--- a/docs/reranking/custom-reranker.mdx
+++ b/docs/reranking/custom-reranker.mdx
@@ -17,7 +17,8 @@ overridden raises `NotImplementedError` rather than silently returning unsorted 
 useful guard, but worth knowing about before you wire up a query path you didn't plan for.
 
 The Python base class exposes hybrid, vector-only, and FTS-only rerank hooks. TypeScript and Rust
-currently expose the custom reranker interface for hybrid reranking.
+currently expose the custom reranker interface for hybrid reranking. In Rust, a custom reranker must
+also satisfy the trait bounds `Debug + Send + Sync`.
 
 ## Interface
 
@@ -33,6 +34,10 @@ Whichever methods you override, your reranker has one job on the way out: attach
 `_relevance_score` column with the most relevant rows at the top. LanceDB will reject the result
 if that column is missing, and downstream `.limit(...)` calls trust the order you return, so
 sort descending before handing the table back.
+
+For vector-only reranking in Python, pass a text query to `.rerank(..., query_string="...")`.
+The vector query itself may be numeric, but `rerank_vector(query, vector_results)` still receives
+a string query so your reranker can score each candidate against the user's text intent.
 
 Below, we show the pseudocode of a custom reranker that combines the results of semantic and full-text
 search using a linear combination of the scores:

--- a/docs/reranking/eval.mdx
+++ b/docs/reranking/eval.mdx
@@ -15,7 +15,7 @@ Combining results from multiple searches thus requires a reranking step.
 
 There are two common approaches for reranking search results from multiple sources.
 
-- **Score-based**: Calculate final relevance scores from the individual search algorithm scores. Examples: Reciprocal Rank Fusion (the default in LanceDB), and weighted linear combination of semantic & keyword-based search scores.
+- **Score-based**: Calculate final relevance scores from the individual search algorithm scores. Examples: Reciprocal Rank Fusion (the default in LanceDB), mean reciprocal rank fusion, and weighted linear combination of semantic and keyword-based search scores.
 
 - **Relevance-based**: Discards the existing scores and calculates the relevance of each search result-query pair. Example: Cross Encoder models
 
@@ -41,9 +41,15 @@ This choice materially affects score-based rerankers (such as `LinearCombination
 when you evaluate score-based strategies, treat `normalize` as a tunable hyperparameter
 alongside the reranker itself.
 
-Even though there may many more strategies for reranking, there are no "universally best"
-ones that work well for all cases, because they be dataset or application specific.
-Evaluating whether a reranking strategy is a good one, is also a challenge. In the next
+For score-based evaluation, the main built-in knobs are:
+
+- `RRFReranker(K=60)`: rank fusion with a positive smoothing constant.
+- `MRRReranker(weight_vector=0.5, weight_fts=0.5)`: weighted reciprocal rank fusion where the weights must sum to `1.0`.
+- `LinearCombinationReranker(weight=0.7, fill=1.0)`: blends vector and FTS scores directly; `fill` controls how strongly to penalize a result missing from one side.
+
+Even though there are many more strategies for reranking, there are no "universally best"
+ones that work well for all cases, because reranking quality is dataset and application specific.
+Evaluating whether a reranking strategy is a good fit is also a challenge. In the next
 section, we discuss an example evaluation of different reranking strategies on a sample dataset.
 
 ## Example evaluation

--- a/docs/reranking/index.mdx
+++ b/docs/reranking/index.mdx
@@ -75,19 +75,26 @@ The model-based rerankers need their provider package installed, and the hosted 
 as an `api_key` argument or set in the provider-specific environment variable.
 
 Rerankers add `_relevance_score` and return rows ordered by descending relevance. Python rerankers
-accept `return_score="relevance"` or `return_score="all"` − use `"all"` when you want to keep the
+accept `return_score="relevance"` or `return_score="all"`; use `"all"` when you want to keep the
 original vector distance or FTS score columns for debugging. Model-based rerankers read from
 `column="text"` by default, so either return that column in the search results or pass a different
 column.
+
+Use `refine_factor` on vector or hybrid queries when you're reranking approximate IVF-PQ results and
+want a larger candidate pool before the final ranking step. A value of `3` asks LanceDB to fetch
+`limit * 3` candidates, refine them with the full vectors, and keep the requested `limit`. Higher
+values can improve recall, but they also increase query latency.
 
 <Note>
 **SDK coverage differs across languages**
 
 The provider-specific rerankers in the table above
 (`CohereReranker`, `CrossEncoderReranker`, `ColbertReranker`, and others under `lancedb.rerankers`)
-are currently **Python-only**. The TypeScript and Rust SDKs currently expose the generic `Reranker`
-interface (`rerankHybrid` / `rerank_hybrid`) and the built-in `RRFReranker`. To use a
-model-based reranker from TypeScript or Rust, you must implement the `Reranker` interface yourself.
+are currently **Python-only**. The TypeScript and Rust SDKs currently expose hybrid reranking through
+the generic `Reranker` interface (`rerankHybrid` / `rerank_hybrid`) and the built-in `RRFReranker`.
+In TypeScript, create the built-in RRF reranker with `await RRFReranker.create(k)`. To use a
+model-based reranker from TypeScript or Rust, you must implement the hybrid reranker interface
+yourself.
 </Note>
 
 

--- a/docs/snippets/tables.mdx
+++ b/docs/snippets/tables.mdx
@@ -12,6 +12,8 @@ export const PyAddDataPydanticModel = "from lancedb.pydantic import LanceModel, 
 
 export const PyAddDataToTable = "import pyarrow as pa\n\n# create an empty table with schema\ndata = [\n    {\"vector\": [3.1, 4.1], \"item\": \"foo\", \"price\": 10.0},\n    {\"vector\": [5.9, 26.5], \"item\": \"bar\", \"price\": 20.0},\n    {\"vector\": [10.2, 100.8], \"item\": \"baz\", \"price\": 30.0},\n    {\"vector\": [1.4, 9.5], \"item\": \"fred\", \"price\": 40.0},\n]\n\nschema = pa.schema(\n    [\n        pa.field(\"vector\", pa.list_(pa.float32(), 2)),\n        pa.field(\"item\", pa.utf8()),\n        pa.field(\"price\", pa.float32()),\n    ]\n)\n\ntable_name = \"basic_ingestion_example\"\ntable = db.create_table(table_name, schema=schema, mode=\"overwrite\")\n# Add data\ntable.add(data)\n";
 
+export const PyAddFeatureColumnsSql = "table.add_columns(\n    {\n        \"price_per_id\": \"cast(price / id as float)\",\n        \"price_log\": \"ln(price)\",\n        \"price_score\": \"cast(price / (price + 100.0) as float)\",\n    }\n)\n";
+
 export const PyAddFromDataset = "import pyarrow.dataset as ds\n\ndataset = ds.dataset(data_path, format=\"parquet\")\ndb = tmp_db\ntable = db.create_table(\"my_table\", schema=dataset.schema, mode=\"overwrite\")\ntable.add(dataset)\n";
 
 export const PyAlterColumnsDataType = "# Change price from int32 to int64 for larger numbers\ntable.alter_columns({\"path\": \"price\", \"data_type\": pa.int64()})\n";
@@ -128,6 +130,8 @@ export const TsAddColumnsDefaultValues = "// Add a stock status column with defa
 
 export const TsAddColumnsNullable = "// Add a nullable timestamp column\nawait schemaAddTable.addColumns([\n  {\n    name: \"last_ordered\",\n    valueSql: \"cast(NULL as timestamp)\",\n  },\n]);\n";
 
+export const TsAddFeatureColumnsSql = "await schemaAddTable.addColumns([\n  {\n    name: \"price_per_id\",\n    valueSql: \"cast(price / id as float)\",\n  },\n  {\n    name: \"price_log\",\n    valueSql: \"ln(price)\",\n  },\n  {\n    name: \"price_score\",\n    valueSql: \"cast(price / (price + 100.0) as float)\",\n  },\n]);\n";
+
 export const TsAlterColumnsDataType = "// Change price from int32 to int64 for larger numbers\nawait schemaAlterTable.alterColumns([\n  { path: \"price\", dataType: new arrow.Int64() },\n]);\n";
 
 export const TsAlterColumnsMultiple = "// Rename, change type, and make nullable in one operation\nawait schemaAlterTable.alterColumns([\n  {\n    path: \"sale_price\",\n    rename: \"final_price\",\n    dataType: new arrow.Float64(),\n    nullable: true,\n  },\n]);\n";
@@ -221,6 +225,8 @@ export const RsAddColumnsCalculated = "// Add a discounted price column (10% dis
 export const RsAddColumnsDefaultValues = "// Add a stock status column with default value\nschema_add_table\n    .add_columns(\n        NewColumnTransform::SqlExpressions(vec![(\n            \"in_stock\".to_string(),\n            \"cast(true as boolean)\".to_string(),\n        )]),\n        None,\n    )\n    .await\n    .unwrap();\n";
 
 export const RsAddColumnsNullable = "// Add a nullable timestamp column\nschema_add_table\n    .add_columns(\n        NewColumnTransform::SqlExpressions(vec![(\n            \"last_ordered\".to_string(),\n            \"cast(NULL as timestamp)\".to_string(),\n        )]),\n        None,\n    )\n    .await\n    .unwrap();\n";
+
+export const RsAddFeatureColumnsSql = "schema_add_table\n    .add_columns(\n        NewColumnTransform::SqlExpressions(vec![\n            (\n                \"price_per_id\".to_string(),\n                \"cast(price / id as float)\".to_string(),\n            ),\n            (\"price_log\".to_string(), \"ln(price)\".to_string()),\n            (\n                \"price_score\".to_string(),\n                \"cast(price / (price + 100.0) as float)\".to_string(),\n            ),\n        ]),\n        None,\n    )\n    .await\n    .unwrap();\n";
 
 export const RsAlterColumnsDataType = "// Change price from int32 to int64 for larger numbers\nschema_alter_table\n    .alter_columns(&[ColumnAlteration::new(\"price\".to_string()).cast_to(DataType::Int64)])\n    .await\n    .unwrap();\n";
 

--- a/docs/tables/index.mdx
+++ b/docs/tables/index.mdx
@@ -243,9 +243,10 @@ Load the data from the JSON file:
     </CodeBlock>
 </CodeGroup >
 
-You can now create a LanceDB table from the loaded data. Use the `mode="overwrite"` to
-replace any existing table with the same name and overwrite its data (useful during
-initial testing).
+You can now create a LanceDB table from the loaded data. By default, creating a table with a name
+that already exists raises an error. Use `mode="overwrite"` only when you intentionally want to
+replace the existing table and its data, or use `exist_ok` / `existOk` when repeatable setup should
+reuse the existing table instead of writing the supplied rows again.
 
 <CodeGroup >
     <CodeBlock filename="Python" language="Python" icon="Python">
@@ -267,6 +268,10 @@ ingestion into a table that already exists, open the table and call `add(...)` i
 `create_table(...)`. For repeatable setup with `exist_ok` / `existOk`, see
 [Handle existing tables](/tables/create#handle-existing-tables).
 </Info>
+
+For more ingestion patterns, including PyArrow tables, Python `pyarrow.dataset.Dataset` inputs,
+empty tables, and Python `LanceModel` schemas with nested fields, see
+[Ingesting data](/tables/create/).
 
 ### From Pandas DataFrames
 <Badge color="green">Python Only</Badge>
@@ -544,6 +549,9 @@ print(r1.sort("power", descending=True).limit(5))
 
 Merlin and Sir Galahad are the most powerful characters when considering the average of
 all their abilities! Sir Lancelot and the Lady of the Lake follow closely behind.
+
+For column renames, type changes, nullability changes, and grouping multiple schema changes into
+one operation, see [Schema and data evolution](/tables/schema/).
 
 ## Delete data
 

--- a/docs/tables/schema.mdx
+++ b/docs/tables/schema.mdx
@@ -17,6 +17,9 @@ import {
     PyAddColumnsNullable as AddColumnsNullable,
     TsAddColumnsNullable as TsAddColumnsNullable,
     RsAddColumnsNullable as RsAddColumnsNullable,
+    PyAddFeatureColumnsSql as AddFeatureColumnsSql,
+    TsAddFeatureColumnsSql as TsAddFeatureColumnsSql,
+    RsAddFeatureColumnsSql as RsAddFeatureColumnsSql,
     PySchemaAlterSetup as SchemaAlterSetup,
     TsSchemaAlterSetup as TsSchemaAlterSetup,
     RsSchemaAlterSetup as RsSchemaAlterSetup,
@@ -100,7 +103,11 @@ First, let's create a sample table with product data to demonstrate schema evolu
 
 ### Add derived columns
 
-You can add new columns that are derived from existing data using SQL expressions:
+You can add new columns that are derived from existing data using SQL expressions.
+For feature engineering on large existing tables, group related derived features into
+one `add_columns` operation instead of running many separate writes. This creates one
+new table version for the schema change and computes the new columns from the existing
+rows, which avoids growing the table's version history with many small updates.
 
 <CodeGroup>
     <CodeBlock filename="Python" language="Python" icon="python">
@@ -115,6 +122,32 @@ You can add new columns that are derived from existing data using SQL expression
     {RsAddColumnsCalculated}
     </CodeBlock>
 </CodeGroup>
+
+The same call can add multiple derived columns at once. For example, if you are
+building several lightweight features from existing product fields, pass all of the
+new column expressions together:
+
+<CodeGroup>
+    <CodeBlock filename="Python" language="Python" icon="python">
+    {AddFeatureColumnsSql}
+    </CodeBlock>
+
+    <CodeBlock filename="TypeScript" language="TypeScript" icon="square-js">
+    {TsAddFeatureColumnsSql}
+    </CodeBlock>
+
+    <CodeBlock filename="Rust" language="Rust" icon="rust">
+    {RsAddFeatureColumnsSql}
+    </CodeBlock>
+</CodeGroup>
+
+<Info>
+LanceDB `add_columns` does not currently accept Python callables, batch UDFs, or
+PyArrow `RecordBatch` iterators for populating new columns. New column values must be
+defined with SQL expressions, or added as NULL columns from an Arrow field or schema.
+If your transformation cannot be expressed in SQL, compute the values outside
+`add_columns` before writing them back through another workflow.
+</Info>
 
 ### Add columns with default values
 

--- a/tests/py/test_tables.py
+++ b/tests/py/test_tables.py
@@ -972,6 +972,21 @@ def test_add_columns_nullable(tmp_db):
     assert "last_ordered" in table.schema.names
 
 
+def test_add_feature_columns_sql(tmp_db):
+    table = _setup_schema_add_table(tmp_db)
+
+    # --8<-- [start:add_feature_columns_sql]
+    table.add_columns(
+        {
+            "price_per_id": "cast(price / id as float)",
+            "price_log": "ln(price)",
+            "price_score": "cast(price / (price + 100.0) as float)",
+        }
+    )
+    # --8<-- [end:add_feature_columns_sql]
+    assert {"price_per_id", "price_log", "price_score"}.issubset(table.schema.names)
+
+
 def test_alter_columns_rename(tmp_db):
     table = _setup_schema_alter_table(tmp_db)
 

--- a/tests/rs/tables.rs
+++ b/tests/rs/tables.rs
@@ -538,6 +538,26 @@ async fn main() {
         .unwrap();
     // --8<-- [end:add_columns_nullable]
 
+    // --8<-- [start:add_feature_columns_sql]
+    schema_add_table
+        .add_columns(
+            NewColumnTransform::SqlExpressions(vec![
+                (
+                    "price_per_id".to_string(),
+                    "cast(price / id as float)".to_string(),
+                ),
+                ("price_log".to_string(), "ln(price)".to_string()),
+                (
+                    "price_score".to_string(),
+                    "cast(price / (price + 100.0) as float)".to_string(),
+                ),
+            ]),
+            None,
+        )
+        .await
+        .unwrap();
+    // --8<-- [end:add_feature_columns_sql]
+
     // --8<-- [start:schema_alter_setup]
     let schema_alter_schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),

--- a/tests/ts/tables.test.ts
+++ b/tests/ts/tables.test.ts
@@ -257,6 +257,26 @@ test("schema evolution snippets (async)", async () => {
     ]);
     // --8<-- [end:add_columns_nullable]
 
+    // --8<-- [start:add_feature_columns_sql]
+    await schemaAddTable.addColumns([
+      {
+        name: "price_per_id",
+        valueSql: "cast(price / id as float)",
+      },
+      {
+        name: "price_log",
+        valueSql: "ln(price)",
+      },
+      {
+        name: "price_score",
+        valueSql: "cast(price / (price + 100.0) as float)",
+      },
+    ]);
+    // --8<-- [end:add_feature_columns_sql]
+    expect((await schemaAddTable.schema()).fields.map((field) => field.name)).toEqual(
+      expect.arrayContaining(["price_per_id", "price_log", "price_score"]),
+    );
+
     // --8<-- [start:schema_alter_setup]
     const schemaAlter = new arrow.Schema([
       new arrow.Field("id", new arrow.Int64()),

--- a/workflows/docs-audit/docs_audit/deterministic_runner.py
+++ b/workflows/docs-audit/docs_audit/deterministic_runner.py
@@ -232,6 +232,28 @@ def extract_code_signals(text: str, keywords: list[str]) -> dict[str, Any]:
 
 
 def repo_snapshot(repo: RepoInfo, refresh: bool, simulate_failure: bool) -> dict[str, Any]:
+    if not repo.path.exists():
+        return {
+            "repo": repo.name,
+            "path": str(repo.path),
+            "branch": "",
+            "sha_before": "",
+            "dirty": False,
+            "refresh_requested": refresh,
+            "refresh_status": "skipped",
+            "message": "Configured repo path does not exist",
+        }
+    if not (repo.path / ".git").exists():
+        return {
+            "repo": repo.name,
+            "path": str(repo.path),
+            "branch": "",
+            "sha_before": "",
+            "dirty": False,
+            "refresh_requested": refresh,
+            "refresh_status": "skipped",
+            "message": "Configured repo path is not a git checkout",
+        }
     branch = run_git(repo.path, ["rev-parse", "--abbrev-ref", "HEAD"]) 
     sha_before = run_git(repo.path, ["rev-parse", "HEAD"])
     dirty = run_git(repo.path, ["status", "--porcelain"])

--- a/workflows/docs-audit/skills/docs-audit-enterprise-summary/SKILL.md
+++ b/workflows/docs-audit/skills/docs-audit-enterprise-summary/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: docs-audit-enterprise-summary
+description: Query and summarize LanceDB docs-audit findings stored in the Enterprise `db://docs-audit` database. Use when the user asks for latest docs gaps, weekly audit gaps, remote audit findings, findings since a date, or summaries from the LanceDB docs audit DB and points to `workflows/docs-audit`, `docs_audit`, or its `.env` credentials.
+---
+
+# Docs Audit Enterprise Summary
+
+## Workflow
+
+Use this skill to inspect completed LanceDB docs-gap audit findings from the Enterprise audit store without exposing credentials.
+
+1. Locate the audit workspace. Prefer a user-provided path; otherwise check the current repo for `workflows/docs-audit`, then `/Users/prrao/code/docs/workflows/docs-audit`.
+2. Load credentials through the audit workspace code. Do not print `.env` values. It should provide `DOCS_AUDIT_DB_URI`, `LANCEDB_API_KEY`, `LANCEDB_HOST_OVERRIDE`, and `LANCEDB_REGION`.
+3. Query `docs_audit_runs` and `docs_audit_findings` in LanceDB Enterprise.
+4. Filter findings to `visibility_class == "public-doc-gap"` and the requested UTC date window.
+5. Summarize by run, area, page, and recurring theme. Keep the final answer focused on actionable documentation gaps, not raw rows.
+
+## Helper Script
+
+Run the bundled script with the docs repo `uv` environment so the audit dependencies are available:
+
+```bash
+cd /Users/prrao/code/docs
+uv run python workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_docs_audit.py \
+  --audit-root /Users/prrao/code/docs/workflows/docs-audit \
+  --start 2026-05-18 \
+  --end 2026-05-25 \
+  --format digest-markdown
+```
+
+Date-only `--end` is treated as inclusive, so `--end 2026-05-25` covers through `2026-05-25T23:59:59Z`. Use an explicit timestamp ending in `Z` when the user asks for an exact exclusive instant.
+
+The script uses `RemoteTable.head(n)` because `RemoteTable.to_arrow()` is not supported on this LanceDB Cloud connection. It drops `embedding`, `embedding_text`, and large run report fields before converting rows. If plain `python3` cannot import `lancedb`, rerun through `uv run python` from `/Users/prrao/code/docs`.
+
+Prefer `--format digest-markdown` or `--format digest-json` for normal answers. These formats keep the payload light by returning counts, affected pages, theme buckets, and a small number of representative examples. Use `--format json` only when the user asks for raw finding records.
+
+## Summarizing Results
+
+In the final response, include:
+
+- the UTC date window used
+- total public findings and runs included
+- counts by area when useful
+- the key gap themes, grouped by docs area or workflow
+- any caveat if the DB query was limited by `--limit`
+
+Do not include API keys, host overrides, raw credentials, embeddings, or long raw finding dumps unless the user explicitly asks for a queue.
+
+## Common Paths
+
+- Audit workspace: `/Users/prrao/code/docs/workflows/docs-audit`
+- Audit package: `/Users/prrao/code/docs/workflows/docs-audit/docs_audit`
+- Repo-local skill: `/Users/prrao/code/docs/workflows/docs-audit/skills/docs-audit-enterprise-summary`
+- Local pulled queue, when present: `/Users/prrao/code/docs/workflows/docs-audit/artifacts/fix-queues/remote-findings-since-2026-05-18.md`

--- a/workflows/docs-audit/skills/docs-audit-enterprise-summary/agents/openai.yaml
+++ b/workflows/docs-audit/skills/docs-audit-enterprise-summary/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Audit Enterprise Summary"
+  short_description: "Query and summarize LanceDB docs-audit Enterprise findings."
+  default_prompt: "Summarize docs-audit Enterprise findings for a date range."

--- a/workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_docs_audit.py
+++ b/workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_docs_audit.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DROP_COLUMNS = {
+    "embedding",
+    "embedding_text",
+    "metadata",
+    "report_text",
+    "refresh",
+    "repo_shas",
+}
+
+THEME_RULES = {
+    "indexing": [
+        ("Index readiness and post-write lifecycle", ("wait_for_index", "num_unindexed_rows", "continuous writes", "index_stats", "optimize()")),
+        ("FTS index/search constraints", ("fts", "full-text", "bm25", "n-gram", "ngram", "tantivy")),
+        ("Vector metric and training correctness", ("distance metric", "train", "training", "metric used")),
+        ("Scalar and quantized index coverage", ("scalar", "btree", "bitmap", "labellist", "ivf_sq", "quantization", "quantized")),
+    ],
+    "search": [
+        ("FTS and SQL FTS workflows", ("fts", "full-text", "nearest_to_text", "nearesttotext", "tantivy", "sql")),
+        ("Hybrid filter and execution behavior", ("hybrid", "prefilter", "postfilter", "filter", "subqueries")),
+        ("Vector and multivector constraints", ("vector", "multivector", "cosine", "dimension", "row id")),
+        ("Query diagnostics, limits, and pagination", ("explain_plan", "analyze_plan", "limit", "offset", "profile", "plan")),
+    ],
+    "table-operations": [
+        ("Create and ingestion semantics", ("create-table", "overwrite", "exist_ok", "ingestion", "table.add", "append")),
+        ("Schema and nullability enforcement", ("schema", "nullable", "nullability", "non-nullable", "vector inference")),
+        ("Mutation return/status semantics", ("update", "delete", "merge", "returned status", "row counts", "commit version")),
+        ("Versioning workflows", ("version", "checkout", "restore", "tags", "managed_versioning")),
+        ("Blob schema contracts", ("blob", "largebinary", "large blob", "lance-encoding")),
+    ],
+    "reranking": [
+        ("Reranker result and score contract", ("_relevance_score", "return_score", "descending", "empty", "score")),
+        ("Rank-fusion scoring knobs", ("linearcombination", "rrf", "mrr", "weight", "fill")),
+        ("Provider/model reranker coverage", ("cohere", "colbert", "openai", "jina", "answerai", "voyage")),
+        ("Cross-SDK support boundaries", ("typescript", "rust", "hybrid reranking", "rerank_vector", "rerank_fts")),
+    ],
+}
+
+
+def parse_instant(value: str, *, end: bool) -> datetime:
+    text = value.strip()
+    if not text:
+        raise ValueError("empty date")
+    date_only = len(text) == 10 and text[4] == "-" and text[7] == "-"
+    if date_only:
+        parsed_date = date.fromisoformat(text)
+        if end:
+            return datetime.combine(parsed_date + timedelta(days=1), time.min, timezone.utc)
+        return datetime.combine(parsed_date, time.min, timezone.utc)
+    normalized = text.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def locate_audit_root(user_path: str | None) -> Path:
+    candidates: list[Path] = []
+    if user_path:
+        candidates.append(Path(user_path).expanduser())
+    cwd = Path.cwd()
+    candidates.extend(
+        [
+            cwd,
+            cwd / "workflows" / "docs-audit",
+            Path("/Users/prrao/code/docs/workflows/docs-audit"),
+        ]
+    )
+    for candidate in candidates:
+        if (candidate / "docs_audit" / "enterprise_store.py").exists():
+            return candidate.resolve()
+    raise RuntimeError(
+        "Could not locate docs-audit workspace. Pass --audit-root pointing at workflows/docs-audit."
+    )
+
+
+def import_audit_modules(audit_root: Path):
+    sys.path.insert(0, str(audit_root))
+    try:
+        from docs_audit.config import load_env_file, settings_from_env
+        from docs_audit.enterprise_store import DocsAuditEnterpriseStore
+    except ModuleNotFoundError as exc:
+        missing = exc.name or str(exc)
+        raise RuntimeError(
+            f"Missing Python dependency '{missing}'. Run this script with the docs repo environment, "
+            "for example: cd /Users/prrao/code/docs && uv run python "
+            "workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_docs_audit.py ..."
+        ) from exc
+
+    return load_env_file, settings_from_env, DocsAuditEnterpriseStore
+
+
+def rows_from_head(table: Any, limit: int) -> list[dict[str, Any]]:
+    arrow = table.head(limit)
+    drop = [name for name in DROP_COLUMNS if name in arrow.column_names]
+    if drop:
+        arrow = arrow.drop(drop)
+    return arrow.to_pylist()
+
+
+def iso(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def clean_finding_text(text: str) -> str:
+    stripped = " ".join(text.strip().split())
+    if stripped.startswith("- "):
+        return stripped[2:]
+    return stripped
+
+
+def classify_theme(area: str, text: str) -> str:
+    lowered = text.lower()
+    for theme, tokens in THEME_RULES.get(area, []):
+        if any(token in lowered for token in tokens):
+            return theme
+    return "Other public docs gaps"
+
+
+def build_digest(
+    *,
+    audit_root: Path,
+    start: datetime,
+    end_exclusive: datetime,
+    limit: int,
+    findings: list[dict[str, Any]],
+    runs: list[dict[str, Any]],
+    examples_per_theme: int,
+) -> dict[str, Any]:
+    by_area = Counter(row.get("area") or "" for row in findings)
+    by_page = Counter((row.get("area") or "", row.get("page_path") or "") for row in findings)
+    pages_by_area: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for (area, page_path), count in sorted(by_page.items()):
+        pages_by_area[area].append({"page_path": page_path, "count": count})
+
+    themes_by_area: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    theme_groups: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in sorted(findings, key=lambda item: (item.get("area") or "", item.get("page_path") or "", item.get("id") or "")):
+        area = row.get("area") or ""
+        text = clean_finding_text(str(row.get("finding_text") or ""))
+        theme = classify_theme(area, text)
+        key = (area, theme)
+        group = theme_groups.setdefault(
+            key,
+            {
+                "theme": theme,
+                "count": 0,
+                "pages": Counter(),
+                "examples": [],
+            },
+        )
+        group["count"] += 1
+        group["pages"][row.get("page_path") or ""] += 1
+        if len(group["examples"]) < examples_per_theme:
+            group["examples"].append(
+                {
+                    "page_path": row.get("page_path") or "",
+                    "finding": text,
+                }
+            )
+
+    for (area, _theme), group in sorted(
+        theme_groups.items(),
+        key=lambda item: (item[0][0], -item[1]["count"], item[0][1]),
+    ):
+        themes_by_area[area].append(
+            {
+                "theme": group["theme"],
+                "count": group["count"],
+                "pages": [
+                    {"page_path": page_path, "count": count}
+                    for page_path, count in group["pages"].most_common()
+                ],
+                "examples": group["examples"],
+            }
+        )
+
+    return {
+        "audit_root": str(audit_root),
+        "window": {
+            "start": iso(start),
+            "end_exclusive": iso(end_exclusive),
+        },
+        "limit": limit,
+        "total_public_findings": len(findings),
+        "runs": [
+            {
+                "run_id": row.get("run_id"),
+                "completed_at": row.get("completed_at"),
+                "areas": row.get("areas"),
+                "selected_pages": row.get("selected_pages"),
+            }
+            for row in runs
+        ],
+        "counts_by_area": dict(sorted(by_area.items())),
+        "pages_by_area": dict(sorted(pages_by_area.items())),
+        "themes_by_area": dict(sorted(themes_by_area.items())),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Query LanceDB docs-audit Enterprise findings for a UTC date window."
+    )
+    parser.add_argument("--audit-root", help="Path to workflows/docs-audit.")
+    parser.add_argument("--start", required=True, help="UTC start date or timestamp.")
+    parser.add_argument("--end", required=True, help="UTC inclusive end date or exclusive timestamp.")
+    parser.add_argument("--limit", type=int, default=5000, help="Maximum rows to fetch with head().")
+    parser.add_argument(
+        "--format",
+        choices=["digest-json", "digest-markdown", "json", "markdown"],
+        default="digest-json",
+        help="Use digest-* for compact high-signal output. Use json for raw findings.",
+    )
+    parser.add_argument(
+        "--examples-per-theme",
+        type=int,
+        default=2,
+        help="Representative finding examples to include for each digest theme.",
+    )
+    args = parser.parse_args()
+
+    start = parse_instant(args.start, end=False)
+    end_exclusive = parse_instant(args.end, end=True)
+    audit_root = locate_audit_root(args.audit_root)
+    load_env_file, settings_from_env, store_cls = import_audit_modules(audit_root)
+
+    load_env_file()
+    settings = settings_from_env()
+    store = store_cls(
+        uri=settings.docs_audit_db_uri,
+        api_key=settings.lancedb_api_key,
+        host_override=settings.lancedb_host_override,
+        region=settings.lancedb_region,
+    )
+
+    run_rows = rows_from_head(store.db.open_table("docs_audit_runs"), args.limit)
+    finding_rows = rows_from_head(store.db.open_table("docs_audit_findings"), args.limit)
+
+    findings = []
+    for row in finding_rows:
+        completed_at = row.get("completed_at")
+        if not isinstance(completed_at, datetime):
+            continue
+        completed_at = completed_at.astimezone(timezone.utc)
+        if start <= completed_at < end_exclusive and row.get("visibility_class") == "public-doc-gap":
+            item = dict(row)
+            item["completed_at"] = iso(completed_at)
+            findings.append(item)
+
+    run_ids = sorted({row["run_id"] for row in findings})
+    runs = []
+    for row in run_rows:
+        if row.get("run_id") in run_ids:
+            item = dict(row)
+            item["completed_at"] = iso(item.get("completed_at"))
+            runs.append(item)
+
+    digest = build_digest(
+        audit_root=audit_root,
+        start=start,
+        end_exclusive=end_exclusive,
+        limit=args.limit,
+        findings=findings,
+        runs=runs,
+        examples_per_theme=max(args.examples_per_theme, 0),
+    )
+
+    raw_payload = {
+        "audit_root": str(audit_root),
+        "window": {
+            "start": iso(start),
+            "end_exclusive": iso(end_exclusive),
+        },
+        "limit": args.limit,
+        "total_public_findings": len(findings),
+        "runs": runs,
+        "counts_by_area": digest["counts_by_area"],
+        "pages_by_area": digest["pages_by_area"],
+        "themes_by_area": digest["themes_by_area"],
+        "findings": sorted(findings, key=lambda row: (row.get("area") or "", row.get("page_path") or "", row.get("id") or "")),
+    }
+
+    if args.format == "json":
+        print(json.dumps(raw_payload, indent=2, sort_keys=True))
+        return 0
+    if args.format == "digest-json":
+        print(json.dumps(digest, indent=2, sort_keys=True))
+        return 0
+
+    print("# Docs Audit Findings")
+    print()
+    print(f"- Window: `{digest['window']['start']}` to `{digest['window']['end_exclusive']}`")
+    print(f"- Public findings: {digest['total_public_findings']}")
+    print(f"- Runs: {len(runs)}")
+    print()
+    for area, count in digest["counts_by_area"].items():
+        print(f"## {area} ({count})")
+        for page in digest["pages_by_area"].get(area, []):
+            print(f"- `{page['page_path']}`: {page['count']}")
+        if args.format == "digest-markdown":
+            print()
+            for theme in digest["themes_by_area"].get(area, []):
+                pages = ", ".join(item["page_path"] for item in theme["pages"][:3])
+                print(f"### {theme['theme']} ({theme['count']})")
+                if pages:
+                    print(f"Pages: {pages}")
+                for example in theme["examples"]:
+                    print(f"- `{example['page_path']}`: {example['finding']}")
+                print()
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_recent_gaps.py
+++ b/workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_recent_gaps.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Retrieve recent docs-audit gaps from the Enterprise LanceDB store.
+
+Returns only the id, date, and description for each gap so a downstream agent
+can summarize without ingesting embeddings or other heavy fields.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+DROP_COLUMNS = {
+    "embedding",
+    "embedding_text",
+    "metadata",
+    "report_text",
+    "refresh",
+    "repo_shas",
+}
+
+
+def locate_audit_root(user_path: str | None) -> Path:
+    candidates: list[Path] = []
+    if user_path:
+        candidates.append(Path(user_path).expanduser())
+    cwd = Path.cwd()
+    candidates.extend(
+        [
+            cwd,
+            cwd / "workflows" / "docs-audit",
+            Path("/Users/prrao/code/docs/workflows/docs-audit"),
+        ]
+    )
+    for candidate in candidates:
+        if (candidate / "docs_audit" / "enterprise_store.py").exists():
+            return candidate.resolve()
+    raise RuntimeError(
+        "Could not locate docs-audit workspace. Pass --audit-root pointing at workflows/docs-audit."
+    )
+
+
+def import_audit_modules(audit_root: Path):
+    sys.path.insert(0, str(audit_root))
+    try:
+        from docs_audit.config import load_env_file, settings_from_env
+        from docs_audit.enterprise_store import DocsAuditEnterpriseStore
+    except ModuleNotFoundError as exc:
+        missing = exc.name or str(exc)
+        raise RuntimeError(
+            f"Missing Python dependency '{missing}'. Run this script with the docs repo environment, "
+            "for example: cd /Users/prrao/code/docs && uv run python "
+            "workflows/docs-audit/skills/docs-audit-enterprise-summary/scripts/query_recent_gaps.py ..."
+        ) from exc
+
+    return load_env_file, settings_from_env, DocsAuditEnterpriseStore
+
+
+def rows_from_head(table: Any, limit: int) -> list[dict[str, Any]]:
+    arrow = table.head(limit)
+    drop = [name for name in DROP_COLUMNS if name in arrow.column_names]
+    if drop:
+        arrow = arrow.drop(drop)
+    return arrow.to_pylist()
+
+
+def iso(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def clean_text(text: str) -> str:
+    stripped = " ".join(text.strip().split())
+    if stripped.startswith("- "):
+        return stripped[2:]
+    return stripped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Retrieve recent docs-audit gaps (id, date, description) from Enterprise LanceDB."
+    )
+    parser.add_argument("--audit-root", help="Path to workflows/docs-audit.")
+    parser.add_argument(
+        "--upto",
+        type=int,
+        default=7,
+        help="How many days back from now to retrieve gaps for (default: 7).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5000,
+        help="Maximum rows to fetch with head().",
+    )
+    args = parser.parse_args()
+
+    if args.upto <= 0:
+        parser.error("--upto must be a positive number of days")
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=args.upto)
+
+    audit_root = locate_audit_root(args.audit_root)
+    load_env_file, settings_from_env, store_cls = import_audit_modules(audit_root)
+
+    load_env_file()
+    settings = settings_from_env()
+    store = store_cls(
+        uri=settings.docs_audit_db_uri,
+        api_key=settings.lancedb_api_key,
+        host_override=settings.lancedb_host_override,
+        region=settings.lancedb_region,
+    )
+
+    finding_rows = rows_from_head(store.db.open_table("docs_audit_findings"), args.limit)
+
+    gaps = []
+    for row in finding_rows:
+        completed_at = row.get("completed_at")
+        if not isinstance(completed_at, datetime):
+            continue
+        completed_at = completed_at.astimezone(timezone.utc)
+        if start <= completed_at < end and row.get("visibility_class") == "public-doc-gap":
+            gaps.append(
+                {
+                    "id": row.get("id"),
+                    "date": iso(completed_at),
+                    "description": clean_text(str(row.get("finding_text") or "")),
+                }
+            )
+
+    gaps.sort(key=lambda item: (item["date"], item["id"] or ""))
+
+    payload = {
+        "window": {
+            "from": iso(start),
+            "to": iso(end),
+            "days": args.upto,
+        },
+        "total_gaps": len(gaps),
+        "gaps": gaps,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/docs-audit/tests/test_deterministic_runner.py
+++ b/workflows/docs-audit/tests/test_deterministic_runner.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from docs_audit.deterministic_runner import RepoInfo, repo_snapshot
+
+
+def test_repo_snapshot_skips_missing_repo_path(tmp_path) -> None:
+    missing_repo = tmp_path / "lancedb"
+
+    snapshot = repo_snapshot(
+        RepoInfo(name="lancedb", path=missing_repo),
+        refresh=True,
+        simulate_failure=False,
+    )
+
+    assert snapshot == {
+        "repo": "lancedb",
+        "path": str(missing_repo),
+        "branch": "",
+        "sha_before": "",
+        "dirty": False,
+        "refresh_requested": True,
+        "refresh_status": "skipped",
+        "message": "Configured repo path does not exist",
+    }
+
+
+def test_repo_snapshot_skips_non_git_repo_path(tmp_path) -> None:
+    non_git_repo = tmp_path / "sophon"
+    non_git_repo.mkdir()
+
+    snapshot = repo_snapshot(
+        RepoInfo(name="sophon", path=non_git_repo),
+        refresh=False,
+        simulate_failure=False,
+    )
+
+    assert snapshot == {
+        "repo": "sophon",
+        "path": str(non_git_repo),
+        "branch": "",
+        "sha_before": "",
+        "dirty": False,
+        "refresh_requested": False,
+        "refresh_status": "skipped",
+        "message": "Configured repo path is not a git checkout",
+    }


### PR DESCRIPTION
## Summary

- Filled selected table-operation docs gaps from the latest audit reports.
  - Clarifies create-table conflict behavior: default create failure, overwrite replacement, and `exist_ok` / `existOk` reuse.
  - Points readers from the basic table guide to richer ingestion and schema-evolution workflows.
  - Keeps the overview concise instead of duplicating detailed table docs.

- Filled selected reranking docs gaps from the latest audit reports.
  - Documents `refine_factor` as the candidate-pool multiplier before reranking.
  - Clarifies Python, TypeScript, and Rust reranking support boundaries.
  - Adds custom reranker details for Python vector-only `query_string` and Rust trait bounds.
  - Adds concise score-based evaluation knobs for RRF, MRR, and linear combination rerankers.

## Validation

- `uv run pytest workflows/docs-audit/tests/test_deterministic_runner.py workflows/docs-audit/tests/test_run_weekly_audit.py`
- `git diff --check HEAD~2..HEAD`
- `make snippets`
- Local build