### PR TITLE
Update new FTS tokenizer language support

### DIFF
--- a/docs/indexing/fts-index.mdx
+++ b/docs/indexing/fts-index.mdx
@@ -3,7 +3,6 @@ title: "Full-Text Search (FTS) Index"
 sidebarTitle: "FTS index"
 description: "Create and tune BM25-based full-text search indexes in LanceDB."
 icon: "book"
-mode: "wide"
 ---
 import { PyFtsIndexAsync as FtsIndexAsync, PyFtsIndexCreate as FtsIndexCreate, PyFtsIndexNested as FtsIndexNested, PyFtsIndexWait as FtsIndexWait } from '/snippets/indexing.mdx';
 
@@ -83,8 +82,8 @@ await async_table.create_index("payload.text", config=FTS(with_position=True))
 | Parameter | Type | Default | Description |
 |:----------|:-----|:--------|:------------|
 | `with_position` | bool | `False` | Store token positions (required for phrase queries) |
-| `base_tokenizer` | str | `"simple"` | Text splitting method (`simple`, `whitespace`, `raw`, `ngram`, `jieba/*`, or `lindera/*`) |
-| `language` | str | `"English"` | Language for stemming/stop words |
+| `base_tokenizer` | str | `"simple"` | Text splitting method (`simple`, `whitespace`, `raw`, `ngram`, `icu`, `jieba/*`, or `lindera/*`) |
+| `language` | str | `"English"` | Language for stemming and stop-word filters. Choose CJK and mixed-language segmentation with `base_tokenizer`. |
 | `max_token_length` | int | `40` | Maximum token size; longer tokens are omitted |
 | `lower_case` | bool | `True` | Lowercase tokens |
 | `stem` | bool | `True` | Apply stemming (`running` → `run`) |
@@ -101,7 +100,19 @@ await async_table.create_index("payload.text", config=FTS(with_position=True))
 - `ascii_folding` helps with international text (e.g., “café” → “cafe”).
 </Note>
 
-Model-backed tokenizers such as `jieba/default` and `lindera/ipadic` require tokenizer model files in Lance's language model home. Lance looks under the default platform data directory for `lance/language_models`, or you can set `LANCE_LANGUAGE_MODEL_HOME` to point to another model root. For example, `jieba/default` is resolved under `<model-home>/jieba/default/...`.
+### Tokenizer choices
+
+`base_tokenizer` controls segmentation before token filters run:
+
+- `simple`, `whitespace`, and `raw` cover common tokenization strategies for space-delimited text.
+- `ngram` indexes overlapping character spans for substring-style matching.
+- `icu` uses bundled ICU4X word segmentation for mixed-language text and scripts where whitespace splitting is not enough. ICU stands for [International Components for Unicode](https://icu.unicode.org/), and this tokenizer does not need external model files.
+- `jieba/*` is for Chinese word segmentation with Jieba.
+- `lindera/*` loads a compiled Lindera dictionary, such as `lindera/ipadic` for Japanese or `lindera/ko-dic` for Korean.
+
+Model-backed tokenizers such as `jieba/default`, `lindera/ipadic`, and `lindera/ko-dic` require tokenizer model files in Lance's language model home. Lance looks under the default platform data directory for `lance/language_models`, or you can set `LANCE_LANGUAGE_MODEL_HOME` to point to another model root. For example, `jieba/default` is resolved under `<model-home>/jieba/default/...`.
+
+`language` is used by token filters, not by the base tokenizer. Stemming supports Arabic, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian, Italian, Norwegian, Portuguese, Romanian, Russian, Spanish, Swedish, Tamil, and Turkish. Built-in stop-word removal supports Danish, Dutch, English, Finnish, French, German, Hungarian, Italian, Norwegian, Portuguese, Russian, Spanish, and Swedish. For other stemming languages, set `remove_stop_words=False` or pass `custom_stop_words`.
 
 ### Phrase Query Configuration
 

--- a/docs/search/full-text-search.mdx
+++ b/docs/search/full-text-search.mdx
@@ -160,7 +160,9 @@ A useful rule of thumb is to call `optimize()` after roughly 100,000 row changes
 
 By default, the text is tokenized by splitting on punctuation and whitespaces, and would filter out words that are longer than 40 characters. All words are converted to lowercase.
 
-Stemming is useful for improving search results by reducing words to their root form, e.g. "running" to "run". LanceDB supports stemming for multiple languages. You should set the `base_tokenizer` parameter rather than `tokenizer_name` because you cannot customize the tokenizer if `tokenizer_name` is specified.
+Stemming is useful for improving search results by reducing words to their root form, e.g. "running" to "run". LanceDB supports stemming for Arabic, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian, Italian, Norwegian, Portuguese, Romanian, Russian, Spanish, Swedish, Tamil, and Turkish. You should set the `base_tokenizer` parameter rather than `tokenizer_name` because you cannot customize the tokenizer if `tokenizer_name` is specified.
+
+Tokenization and language filters are separate settings. `base_tokenizer` controls how text is split into searchable tokens. `language` controls stemming and stop-word removal when `stem=True` or `remove_stop_words=True`; choose the tokenizer for CJK or mixed-language segmentation.
 
 For example, to enable stemming for English:
 
@@ -183,7 +185,9 @@ The tokenizer is customizable, you can specify how the tokenizer splits the text
 - `ascii_folding`: true
 - `custom_stop_words`: `None` — pass a `list[str]` to drop additional words beyond the language defaults. Requires `remove_stop_words=True`.
 
-The Python API also supports tokenizer implementations that load language model files. Use `base_tokenizer="jieba/default"` for Jieba tokenization, which segments Chinese text into searchable word tokens when the text is written without spaces between words. Use `base_tokenizer="lindera/ipadic"` for Lindera IPADIC tokenization of Japanese text. The `language` parameter still controls stemming and stop-word removal; it is not the primary way to enable CJK tokenization.
+For multilingual use cases, use `base_tokenizer="icu"` for unicode-aware word segmentation on mixed-language text. ICU stands for [International Components for Unicode](https://icu.unicode.org/). The ICU tokenizer uses bundled ICU4X segmenter data, so it does not require external tokenizer model files. It is a good default when documents mix languages or include scripts where the simple tokenizer would keep an unspaced span as one large token.
+
+The Python API also supports tokenizer implementations that load language model files. Use `base_tokenizer="jieba/default"` for Jieba tokenization, which segments Chinese text into searchable word tokens when the text is written without spaces between words. Use Lindera-backed tokenizers for dictionary-based East Asian morphological segmentation, such as `base_tokenizer="lindera/ipadic"` for Japanese or `base_tokenizer="lindera/ko-dic"` for Korean when you have installed and compiled that Lindera model. These are language-specific tokenizers; ICU is the broader mixed-language option.
 
 <CodeGroup>
 ```python Python icon="python"
@@ -204,7 +208,11 @@ Model-backed tokenizers require tokenizer model files in Lance's language model 
 export LANCE_LANGUAGE_MODEL_HOME=/path/to/lance/language_models
 ```
 
-For example, `jieba/default` is resolved under `<model-home>/jieba/default/...`, and `lindera/ipadic` is resolved under `<model-home>/lindera/ipadic/...`.
+For example, `jieba/default` is resolved under `<model-home>/jieba/default/...`, `lindera/ipadic` under `<model-home>/lindera/ipadic/...`, and `lindera/ko-dic` under `<model-home>/lindera/ko-dic/...`.
+
+<Note>
+Built-in stop-word removal supports Danish, Dutch, English, Finnish, French, German, Hungarian, Italian, Norwegian, Portuguese, Russian, Spanish, and Swedish. If you use another stemming language, such as Arabic, Greek, Romanian, Tamil, or Turkish, set `remove_stop_words=False` or pass `custom_stop_words`.
+</Note>
 
 For example, for language with accents, you can specify the tokenizer to use `ascii_folding` to remove accents, e.g. 'é' to 'e':
 


### PR DESCRIPTION
## Summary
- document ICU as the bundled mixed-language FTS tokenizer and link to the canonical ICU reference
- clarify Jieba, Lindera, Korean ko-dic, and model-home expectations
- distinguish base tokenization from stemming and stop-word language filters
- remove wide mode from the FTS index page

## Validation
- [x] Ran local `mint dev` to verify