### PR TITLE
chore(ci): merge OpenAPI sync PR via direct merge instead of auto-merge

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -44,10 +44,17 @@ jobs:
           branch: "chore/sync-openapi"
           delete-branch: true
 
-      - name: Enable auto-merge (when checks pass)
+      - name: Wait for checks and merge
         if: steps.cpr.outputs.pull-request-number != ''
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.DOCS_BOT_TOKEN }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          pr="${{ steps.cpr.outputs.pull-request-number }}"
+          # Give the pull_request workflow a moment to register checks before watching.
+          for i in $(seq 1 10); do
+            if gh pr checks "$pr" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then break; fi
+            sleep 15
+          done
+          gh pr checks "$pr" -R "$GITHUB_REPOSITORY" --watch --fail-fast --interval 30
+          gh pr merge "$pr" -R "$GITHUB_REPOSITORY" --squash --delete-branch


### PR DESCRIPTION
## What

The **Sync OpenAPI Spec** workflow merged its PR with `peter-evans/enable-pull-request-automerge`, which requires the repo-level **Allow auto-merge** setting. That setting is now disabled (to stop an external agent from queueing auto-merges without human review), so the step fails:

```
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

## Change

Replace the auto-merge step with a **direct merge**: wait for the required `broken-links-and-openapi` check to pass, then squash-merge immediately. A direct merge does not depend on the auto-merge toggle, so it can stay off permanently.

## Why this is safe

- The trusted sync identity (`DOCS_BOT_TOKEN`) holds the **Repository admin** ruleset bypass, so it clears the required-review gate while untrusted actors (e.g. the mintlify agent) stay blocked.
- `allow_auto_merge` remains `false`, permanently denying the auto-merge queue that was previously abused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)