### PR TITLE
docs: document approx_mode tuning

### DIFF
--- a/docs/search/vector-search.mdx
+++ b/docs/search/vector-search.mdx
@@ -152,7 +152,7 @@ When a vector index is used, `_distance` is not always the true distance between
 ### Exact vs Approximate Distances
 
 When doing vector search, the meaning of "distance" depends on whether you are using an index and whether `refine_factor` is specified as part of your query.
-`nprobes` controls how many partitions are searched to find candidates, while `refine_factor` controls how many candidates are rescored on full vectors for better distance fidelity and reranking quality.
+`nprobes` controls how many partitions are searched to find candidates, `approx_mode` controls the query-time speed/recall trade-off for RQ-quantized indexes, and `refine_factor` controls how many candidates are rescored on full vectors for better distance fidelity and reranking quality.
 
 The table below summarizes the behavior of `_distance` in search results based on your query configuration:
 
@@ -179,6 +179,20 @@ The table below summarizes the behavior of `_distance` in search results based o
 
 For deeper tuning guidance on indexing and performance estimation, see the [vector indexes](/indexing/vector-index/#search-configuration) page,
 For tuning `nprobes`, see below.
+
+### Tuning `approx_mode`
+
+Use `approx_mode` when you want to adjust the speed/recall trade-off for approximate vector search at query time. This setting currently applies only to RQ-quantized indexes, such as `IVF_RQ`; other index types ignore it.
+
+The supported values are:
+
+| Value | Behavior |
+| :--- | :--- |
+| `fast` | Prefer lower query latency, which can reduce recall. |
+| `normal` | Use the default balance between query latency and recall. This only has an effect for RQ indexes built with `num_bits > 1`. |
+| `accurate` | Prefer higher recall, which can increase query latency. |
+
+You can change `approx_mode` per query without rebuilding the index. For RQ indexes built with `num_bits=1`, `normal` uses the same one-bit scoring path as `fast`. If you also set `refine_factor`, LanceDB first uses `approx_mode` while finding candidates, then reranks the selected candidates on full vectors.
 
 ### Tuning `nprobes`
 


### PR DESCRIPTION
## Summary

- Document the query-time `approx_mode` parameter in the vector search ANN index docs.
- List the supported `fast`, `normal`, and `accurate` modes and their speed/recall trade-offs.
- Clarify that `normal` only has an effect for RQ indexes built with `num_bits > 1`; for `num_bits=1`, it uses the same one-bit scoring path as `fast`.
- Note that `approx_mode` can be changed per query without rebuilding the index and interacts with `refine_factor` before reranking.

## Validation

- `uv run python - <<'PY' ...` content check for the new `approx_mode` docs section
- `uv run pytest tests/py/test_search.py` (15 passed, 2 skipped)
