### PR TITLE
docs(quantization): soften multi-bit RaBitQ cost framing, add cross-version note

### DIFF
--- a/docs/indexing/quantization.mdx
+++ b/docs/indexing/quantization.mdx
@@ -54,10 +54,15 @@ When using `IVF_RQ`, vector dimensions must be divisible by `8`.
 
 `num_bits` controls how many bits per dimension are used:
 
+1 bit is the classic RaBitQ setting. You can set it to 2, 4, or 8 bits to improve fidelity for better precision or recall — the main trade-off is additional storage for the extra bits per dimension, with only a modest increase in query-time compute.
+It's also possible to tune the number of IVF partitions in `IVF_RQ`, similar to how you would do in `IVF_PQ`.
+
+<Warning title="Reading multi-bit indexes across versions">
+Indexes built with `num_bits >= 2` use an updated on-disk layout. Older LanceDB versions cannot read them and will fail with a clear missing-column error rather than returning incorrect results. Existing indexes keep working and upgrade automatically when they are rewritten (for example, during compaction, optimize, or remap). `num_bits=1` indexes are unaffected in both directions.
+</Warning>
+
 ## API Reference
 
-1 bit is the classic RaBitQ setting, but you could (at higher computational cost) set it to 2, 4 or 8 bits if you want to improve the fidelity for better precision or recall.
-It's also possible to tune the number of IVF partitions in `IVF_RQ`, similar to how you would do in `IVF_PQ`.
 The full list of parameters to the algorithm are listed below.
 
 - `distance_type`: Literal["l2", "cosine", "dot"], defaults to "l2"  
@@ -65,7 +70,7 @@ The full list of parameters to the algorithm are listed below.
 - `num_partitions`: Optional[int], defaults to None  
   Number of IVF partitions (affects index build time and query accuracy). More partitions can improve recall but may increase build time.
 - `num_bits`: int, defaults to 1  
-  Bits per dimension for quantization (1 is standard RaBitQ). Higher values improve fidelity at the cost of more storage and computation.
+  Bits per dimension for quantization (1 is standard RaBitQ). Higher values improve fidelity, mainly at the cost of additional storage.
 - `max_iterations`: int, defaults to 50  
   Maximum number of iterations for training the quantizer. Increase for larger datasets or to improve quantization quality.
 - `sample_rate`: int, defaults to 256  


### PR DESCRIPTION
## What

Updates the RaBitQ section of the quantization docs in light of [lance#7205](https://github.com/lance-format/lance/pull/7205), which added dedicated SIMD kernels for multi-bit (`num_bits >= 2`) RaBitQ ex-code reranking.

- **Soften the multi-bit cost framing.** The docs previously steered users away from `num_bits >= 2` on a "higher computational cost" basis. With the new SIMD rerank kernels, that's outdated — the real trade-off is storage. Reworded both the prose and the `num_bits` parameter description accordingly.
- **Add a cross-version compatibility warning.** Multi-bit indexes use an updated on-disk layout that older LanceDB versions cannot read (loud missing-column error, not silent corruption). Existing indexes keep working and upgrade automatically on rewrite; `num_bits=1` is unaffected in both directions.
- **Move the `## API Reference` heading** below the conceptual prose so it sits directly above the parameter list it introduces (it previously sat above the explanatory text, which read oddly).

## Why

This is the durable, user-facing residue of the lance perf work — not a "we got faster" announcement (that belongs in release notes), but a correction to framing that would otherwise steer people away from multi-bit on outdated grounds, plus the one piece with real user impact: the version-compatibility break.

## Notes

- Assumes the new on-disk format ships with the upcoming LanceDB release (lance core is vendored into the latest LanceDB).
- Used `<Warning>` rather than the page's usual `<Note>` deliberately — a breaking-compat item warrants the higher severity styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)