### PR TITLE
chore(docs): sync OpenAPI spec

### DIFF
--- a/docs/api-reference/rest/openapi.yml
+++ b/docs/api-reference/rest/openapi.yml
@@ -2738,6 +2738,12 @@ components:
           type: integer
           format: int64
           minimum: 0
+        tag:
+          description: |
+            Tag name to describe the table at.
+            If specified, the server should resolve the tag to a version number and describe that version.
+            Cannot be used together with `version` or `branch`.
+          type: string
         branch:
           type: string
           description: |


### PR DESCRIPTION
Syncs `docs/api-reference/rest/openapi.yml` from `lance-format/lance-namespace` (`docs/src/rest.yaml`).