### PR TITLE
chore(docs): sync OpenAPI spec

### DIFF
--- a/docs/api-reference/rest/openapi.yml
+++ b/docs/api-reference/rest/openapi.yml
@@ -247,6 +247,12 @@ paths:
 
         This operation must behave exactly like the DescribeNamespace API,
         except it does not contain a response body.
+
+        REST NAMESPACE ONLY
+        REST namespace conveys the result through the HTTP status code with no response body.
+        The REST response maps to the `NamespaceExistsResponse` model as follows:
+        - a `200` response means the namespace exists; a `404` response means it does not
+        - response headers map to `context` via the `header.` prefix (see the `Context` schema)
       requestBody:
         required: true
         content:
@@ -441,6 +447,12 @@ paths:
 
         This operation should behave exactly like DescribeTable,
         except it does not contain a response body.
+
+        REST NAMESPACE ONLY
+        REST namespace conveys the result through the HTTP status code with no response body.
+        The REST response maps to the `TableExistsResponse` model as follows:
+        - a `200` response means the table exists; a `404` response means it does not
+        - response headers map to `context` via the `header.` prefix (see the `Context` schema)
 
         For DirectoryNamespace implementation, a table exists if either:
         - The table has Lance data versions (regular table created with CreateTable)
@@ -1299,6 +1311,9 @@ paths:
         REST NAMESPACE ONLY
         REST namespace returns the response as Arrow IPC file binary data
         instead of the `QueryTableResponse` JSON object.
+        The REST response maps to the `QueryTableResponse` model as follows:
+        - the Arrow IPC file binary body maps to `data`
+        - response headers map to `context` via the `header.` prefix (see the `Context` schema)
       requestBody:
         description: Query request
         content:
@@ -1338,6 +1353,9 @@ paths:
         REST NAMESPACE ONLY
         REST namespace returns the response as a plain integer
         instead of the `CountTableRowsResponse` JSON object.
+        The REST response maps to the `CountTableRowsResponse` model as follows:
+        - the integer response body maps to `count`
+        - response headers map to `context` via the `header.` prefix (see the `Context` schema)
       requestBody:
         required: true
         content:
@@ -2367,6 +2385,8 @@ components:
       required:
         - code
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         error:
           type: string
           description: A brief, human-readable message about the error.
@@ -2441,13 +2461,21 @@ components:
     Context:
       type: object
       description: |
-        Arbitrary context for a request as key-value pairs.
+        Arbitrary context as key-value pairs.
         How to use the context is custom to the specific implementation.
 
+        On a request, it carries caller-provided context to the implementation.
+        On a response, it carries implementation-provided context back to the caller.
+
         REST NAMESPACE ONLY
-        Context entries are passed via HTTP headers using the naming convention
-        `x-lance-ctx-<key>: <value>`. For example, a context entry
-        `{"trace_id": "abc123"}` would be sent as the header `x-lance-ctx-trace_id: abc123`.
+        Context entries are mapped to and from HTTP headers using the `header.` prefix:
+        - On a request, any entry whose key starts with `header.` is sent as an HTTP
+          request header with the prefix stripped. For example, the entry
+          `{"header.Authorization": "Bearer abc"}` is sent as the request header
+          `Authorization: Bearer abc`.
+        - On a response, every HTTP response header is returned as an entry whose key is the
+          header name prefixed with `header.`. For example, the response header
+          `x-request-id: abc123` is returned as the entry `{"header.x-request-id": "abc123"}`.
       additionalProperties:
         type: string
 
@@ -2481,6 +2509,8 @@ components:
     CreateNamespaceResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -2515,6 +2545,8 @@ components:
       required:
         - namespaces
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         namespaces:
           type: array
           uniqueItems: true
@@ -2540,6 +2572,8 @@ components:
     DescribeNamespaceResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         properties:
           type: object
           description:
@@ -2582,6 +2616,8 @@ components:
     DropNamespaceResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         properties:
           type: object
           description: |
@@ -2606,6 +2642,18 @@ components:
           type: array
           items:
             type: string
+
+    NamespaceExistsResponse:
+      type: object
+      description: |
+        Response for a namespace existence check.
+
+        The REST namespace does not transmit this object directly (see the NamespaceExists
+        operation for how the status-code response maps to it). It is the standard data model
+        for the LanceNamespace interfaces (e.g. Java, Python).
+      properties:
+        context:
+          $ref: "#/components/schemas/Context"
 
     PageToken:
       description: |
@@ -2667,6 +2715,8 @@ components:
     RegisterTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -2708,6 +2758,8 @@ components:
       required:
         - tables
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         tables:
           type: array
           uniqueItems: true
@@ -2782,6 +2834,8 @@ components:
     DescribeTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         table:
           type: string
           description: |
@@ -2917,12 +2971,21 @@ components:
           type: string
 
     CountTableRowsResponse:
-      type: integer
-      format: int64
+      type: object
       description: |
         Response containing the count of rows.
-        Serializes transparently as just the number for backward compatibility.
-      minimum: 0
+
+        The REST namespace does not transmit this object directly (see the CountTableRows
+        operation for how the bare-number response maps to it). It is the standard data model
+        for the LanceNamespace interfaces (e.g. Java, Python).
+      properties:
+        context:
+          $ref: "#/components/schemas/Context"
+        count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: The count of rows.
 
     InsertIntoTableRequest:
       type: object
@@ -2953,6 +3016,8 @@ components:
       type: object
       description: Response from inserting records into a table
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3008,6 +3073,8 @@ components:
       type: object
       description: Response from merge insert operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3079,6 +3146,8 @@ components:
         - updated_rows
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3127,6 +3196,8 @@ components:
     DeleteFromTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3259,6 +3330,22 @@ components:
           type: boolean
           description: If true, return the row id as a column called `_rowid`
 
+    QueryTableResponse:
+      type: object
+      description: |
+        Query results.
+
+        The REST namespace does not transmit this object directly (see the QueryTable
+        operation for how the Arrow IPC binary response maps to it). It is the standard data
+        model for the LanceNamespace interfaces (e.g. Java, Python).
+      properties:
+        context:
+          $ref: "#/components/schemas/Context"
+        data:
+          type: string
+          format: binary
+          description: Query results as Arrow IPC file binary data.
+
     CreateTableIndexRequest:
       type: object
       required:
@@ -3329,6 +3416,8 @@ components:
       type: object
       description: Response for create index operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3337,6 +3426,8 @@ components:
       type: object
       description: Response for create scalar index operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3373,6 +3464,8 @@ components:
       required:
         - indexes
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         indexes:
           type: array
           items:
@@ -3485,6 +3578,8 @@ components:
     DescribeTableIndexStatsResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         distance_type:
           type: string
           nullable: true
@@ -3617,6 +3712,8 @@ components:
     CreateTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3683,6 +3780,8 @@ components:
       description: |
         Response for declaring a table.
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3731,6 +3830,18 @@ components:
           format: int64
           minimum: 0
 
+    TableExistsResponse:
+      type: object
+      description: |
+        Response for a table existence check.
+
+        The REST namespace does not transmit this object directly (see the TableExists
+        operation for how the status-code response maps to it). It is the standard data model
+        for the LanceNamespace interfaces (e.g. Java, Python).
+      properties:
+        context:
+          $ref: "#/components/schemas/Context"
+
     TransactionStatus:
       type: string
       description: |
@@ -3759,6 +3870,8 @@ components:
       required:
         - status
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         status:
           $ref: "#/components/schemas/TransactionStatus"
         properties:
@@ -3850,6 +3963,8 @@ components:
       required:
         - status
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         status:
           $ref: "#/components/schemas/TransactionStatus"
         properties:
@@ -3875,6 +3990,8 @@ components:
     DropTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -3911,6 +4028,8 @@ components:
     DeregisterTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4106,6 +4225,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           type: integer
           format: int64
@@ -4148,6 +4269,8 @@ components:
       type: object
       description: Response for create tag operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4173,6 +4296,8 @@ components:
       type: object
       description: Response for delete tag operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4208,6 +4333,8 @@ components:
       type: object
       description: Response for update tag operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4235,6 +4362,8 @@ components:
       required:
         - tags
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         tags:
           type: object
           additionalProperties:
@@ -4329,6 +4458,8 @@ components:
       type: object
       description: Response for create branch operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4354,6 +4485,8 @@ components:
       type: object
       description: Response for delete branch operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4381,6 +4514,8 @@ components:
       required:
         - branches
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         branches:
           type: object
           additionalProperties:
@@ -4416,6 +4551,8 @@ components:
       type: object
       description: Response for restore table operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4446,6 +4583,8 @@ components:
     RenameTableResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4475,6 +4614,8 @@ components:
     UpdateTableSchemaMetadataResponse:
       type: object
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         metadata:
           type: object
           additionalProperties:
@@ -4514,6 +4655,8 @@ components:
       required:
         - versions
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         versions:
           type: array
           items:
@@ -4575,6 +4718,8 @@ components:
       type: object
       description: Response for creating a table version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4610,6 +4755,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           $ref: "#/components/schemas/TableVersion"
           description: The table version information
@@ -4670,6 +4817,8 @@ components:
       type: object
       description: Response for deleting table version records
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         deleted_count:
           type: integer
           format: int64
@@ -4749,6 +4898,8 @@ components:
       required:
         - versions
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -4831,6 +4982,8 @@ components:
       required:
         - results
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier for the batch commit
@@ -4919,6 +5072,8 @@ components:
       required:
         - plan
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         plan:
           type: string
           description: Human-readable query execution plan
@@ -5051,6 +5206,8 @@ components:
       required:
         - analysis
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         analysis:
           type: string
           description: Detailed analysis of the query execution plan
@@ -5062,6 +5219,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5190,6 +5349,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           type: integer
           format: int64
@@ -5203,6 +5364,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5250,6 +5413,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           type: integer
           format: int64
@@ -5271,6 +5436,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5378,6 +5545,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           type: integer
           format: int64
@@ -5391,6 +5560,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5475,6 +5646,8 @@ components:
       required:
         - job_id
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         job_id:
           type: string
           description: The job ID for tracking the backfill job
@@ -5484,6 +5657,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5543,6 +5718,8 @@ components:
       required:
         - job_id
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         job_id:
           type: string
           description: The job ID for tracking the refresh job
@@ -5556,6 +5733,8 @@ components:
       properties:
         identity:
           $ref: "#/components/schemas/Identity"
+        context:
+          $ref: "#/components/schemas/Context"
         id:
           type: array
           items:
@@ -5704,6 +5883,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         version:
           type: integer
           format: int64
@@ -5745,6 +5926,8 @@ components:
       required:
         - version
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -5778,6 +5961,8 @@ components:
         - num_indices
         - fragment_stats
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         total_bytes:
           type: integer
           format: int64
@@ -5881,6 +6066,8 @@ components:
       type: object
       description: Response for drop index operation
       properties:
+        context:
+          $ref: "#/components/schemas/Context"
         transaction_id:
           type: string
           description: Optional transaction identifier
@@ -6003,7 +6190,12 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/CountTableRowsResponse"
+            type: integer
+            format: int64
+            minimum: 0
+            description: |
+              Row count serialized transparently as a bare number for the REST namespace.
+              The CountTableRowsResponse object model is used by non-REST interfaces.
 
     CreateTableResponse:
       description: Table properties result when creating a table


### PR DESCRIPTION
Syncs `docs/api-reference/rest/openapi.yml` from `lance-format/lance-namespace` (`docs/src/rest.yaml`).