### PR TITLE
docs: rewrite write performance/ingestion section

### DIFF
--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -62,9 +62,9 @@ For very large initial loads, create the table empty first; passing data directl
 Scanning a `pyarrow.dataset.Dataset` or `LanceDataset` for `add()` automatically bounds the scanner's batch size and read-ahead based on the schema's bytes-per-row, so wide-row datasets (large embedding columns, long text, many columns) stay near a ~1 GiB in-flight budget during the scan. Narrow datasets keep PyArrow's defaults, so throughput is unaffected.
 </Note>
 
-### Iterator ingestion: for streaming or computed-on-the-fly data
+### Iterator ingestion: for data you transform on the fly
 
-If your dataset doesn't fit in memory all at once — rows computed on the fly (generating embeddings as you ingest), or pulled from a streaming source — materializing the full table before calling `add()` will run you out of memory. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead. LanceDB consumes one batch at a time, so peak memory stays bounded by the batch size you yield.
+If each row needs work before it can be written — generating embeddings as you ingest, for example — the data doesn't exist as a file you can point `ds.dataset(...)` at. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead; LanceDB consumes one batch at a time as you produce them.
 
 ```python Python icon="python"
 def stream():
@@ -75,13 +75,19 @@ def stream():
 table.add(stream())
 ```
 
-Use decently large chunks of several thousand rows or more, rather than yielding single-row batches. Unlike a `Dataset`, a reader can't be counted ahead of time, so LanceDB can't auto-size parallelism for it — set `write_parallelism` yourself:
+Use decently large chunks of several thousand rows or more, rather than yielding single-row batches.
+
+<Note>
+**Set `write_parallelism` yourself for large inputs**
+
+Unlike a `Dataset`, a reader can't be counted or rescanned ahead of time, so LanceDB can't auto-size parallelism for it. For large inputs, set `write_parallelism` explicitly:
 
 ```python Python icon="python"
 table.add(stream(), write_parallelism=4)
 ```
 
-More parallelism means more write bandwidth, but each partition also becomes its own fragment, so over-parallelizing a small stream just fragments the table for no benefit. As a rule of thumb, don't budget more than one unit of parallelism per ~100K rows or ~1 GB of data — a 1,000-row stream needs `write_parallelism=1`, not more. `write_parallelism` is also a memory knob independent of that tradeoff: each partition buffers a batch in flight, so lower it if ingestion is using more memory than expected.
+More parallelism means more write bandwidth, but each partition also becomes its own fragment, so don't over-allocate on a small input — budget one unit of parallelism per ~100K rows or ~1 GB of data as a rule of thumb.
+</Note>
 
 ## Indexing
 

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -34,7 +34,7 @@ Use `add()` for pure appends, and reach for `merge_insert()` only when you need 
 
 ### Bulk ingestion: for data you already have
 
-For materialized inputs (Arrow Tables, DataFrames) and file-backed sources (`pyarrow.dataset(...)`), LanceDB auto-parallelizes the write across workers, estimating the partition count from the data size. The main benefit is write bandwidth: partitions write concurrently, so more of them means more throughput, up to the number of CPU cores available.
+For materialized inputs (Arrow Tables, DataFrames) and file-backed sources (`pyarrow.dataset(...)`), LanceDB auto-parallelizes the write across workers, estimating the partition count from the data size — more partitions means more concurrent writes and higher throughput, up to the CPU core count.
 
 ```python Python icon="python"
 table.add(arrow_table)                              # in-memory
@@ -42,7 +42,7 @@ table.add(df)                                       # pandas
 table.add(ds.dataset("data/", format="parquet"))    # streams from disk, still parallelized
 ```
 
-Pass `progress=True` to watch it happen: LanceDB displays a live tqdm bar with rows written, write throughput in MB/s, and how many of the available workers are active.
+Pass `progress=True` to watch it happen: LanceDB shows a live tqdm bar with rows written, throughput in MB/s, and active worker count.
 
 ```python Python icon="python"
 table.add(ds.dataset("data/", format="parquet"), progress=True)
@@ -52,7 +52,7 @@ table.add(ds.dataset("data/", format="parquet"), progress=True)
 71%|███████▏  | 710000/1000000 [00:12<00:05, 58.8kit/s, 42.3 MB/s | 8/8 workers]
 ```
 
-For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over building your own `pyarrow.RecordBatchReader`. Both stream without loading the whole table into memory, but only a `Dataset` can be counted and rescanned: LanceDB knows the total row count upfront, which lets it auto-size parallelism, and it can retry a failed write by rescanning from the start. A hand-built reader can only be consumed once, so neither is possible — reach for the iterator path below only when the data genuinely can't be backed by files, e.g. embeddings computed on the fly.
+For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over a hand-built `pyarrow.RecordBatchReader`: a `Dataset` can be counted and rescanned, so LanceDB knows the row count upfront (better auto-parallelism) and can retry a failed write from the start — a reader can only be consumed once, so neither is possible. Reach for the iterator path below only when the data genuinely can't be backed by files, e.g. embeddings computed on the fly.
 
 For very large initial loads, create the table empty first; passing data directly to `create_table(name, data)` skips the auto-parallel path.
 
@@ -80,13 +80,13 @@ Use decently large chunks of several thousand rows or more, rather than yielding
 <Note>
 **Set `write_parallelism` yourself for large inputs**
 
-Unlike a `Dataset`, a reader can't be counted or rescanned ahead of time, so LanceDB can't auto-size parallelism for it. For large inputs, set `write_parallelism` explicitly:
+A reader can't be counted or rescanned the way a `Dataset` can (see above), so LanceDB can't auto-size parallelism for it — set `write_parallelism` explicitly for large inputs:
 
 ```python Python icon="python"
 table.add(stream(), write_parallelism=4)
 ```
 
-More parallelism means more write bandwidth, but each partition also becomes its own fragment, so don't over-allocate on a small input — budget one unit of parallelism per ~100K rows or ~1 GB of data as a rule of thumb.
+Each partition becomes its own fragment, so don't over-allocate on a small input — budget one unit of parallelism per ~100K rows or ~1 GB of data as a rule of thumb.
 </Note>
 
 ## Indexing

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -48,6 +48,10 @@ Pass `progress=True` to watch it happen: LanceDB displays a live tqdm bar with r
 table.add(ds.dataset("data/", format="parquet"), progress=True)
 ```
 
+```text
+71%|███████▏  | 710000/1000000 [00:12<00:05, 58.8kit/s, 42.3 MB/s | 8/8 workers]
+```
+
 For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over building your own `pyarrow.RecordBatchReader`. Both stream without loading the whole table into memory, but only a `Dataset` can be counted and rescanned: LanceDB knows the total row count upfront, which lets it auto-size parallelism, and it can retry a failed write by rescanning from the start. A hand-built reader can only be consumed once, so neither is possible — reach for the iterator path below only when the data genuinely can't be backed by files, e.g. embeddings computed on the fly.
 
 For very large initial loads, create the table empty first; passing data directly to `create_table(name, data)` skips the auto-parallel path.

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -34,7 +34,7 @@ Use `add()` for pure appends, and reach for `merge_insert()` only when you need 
 
 ### Bulk ingestion: for data you already have
 
-For materialized inputs (Arrow Tables, DataFrames, `pyarrow.dataset(...)`), LanceDB auto-parallelizes the write across workers.
+For materialized inputs (Arrow Tables, DataFrames) and file-backed sources (`pyarrow.dataset(...)`), LanceDB auto-parallelizes the write across workers, estimating the partition count from the data size. The main benefit is write bandwidth: partitions write concurrently, so more of them means more throughput, up to the number of CPU cores available.
 
 ```python Python icon="python"
 table.add(arrow_table)                              # in-memory
@@ -42,11 +42,25 @@ table.add(df)                                       # pandas
 table.add(ds.dataset("data/", format="parquet"))    # streams from disk, still parallelized
 ```
 
-`pa.dataset(...)` is the right choice for large file-based loads: it streams Parquet/CSV without loading into memory, and still preserves auto-parallelism. For very large initial loads, create the table empty first; passing data directly to `create_table(name, data)` skips the auto-parallel path.
+Pass `progress=True` to watch it happen: LanceDB displays a live tqdm bar with rows written, write throughput in MB/s, and how many of the available workers are active.
+
+```python Python icon="python"
+table.add(ds.dataset("data/", format="parquet"), progress=True)
+```
+
+For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over building your own `pyarrow.RecordBatchReader`. Both stream without loading the whole table into memory, but only a `Dataset` can be counted and rescanned: LanceDB knows the total row count upfront, which lets it auto-size parallelism, and it can retry a failed write by rescanning from the start. A hand-built reader can only be consumed once, so neither is possible — reach for the iterator path below only when the data genuinely can't be backed by files, e.g. embeddings computed on the fly.
+
+For very large initial loads, create the table empty first; passing data directly to `create_table(name, data)` skips the auto-parallel path.
+
+<Note>
+**Wide rows and scan memory**
+
+Scanning a `pyarrow.dataset.Dataset` or `LanceDataset` for `add()` automatically bounds the scanner's batch size and read-ahead based on the schema's bytes-per-row, so wide-row datasets (large embedding columns, long text, many columns) stay near a ~1 GiB in-flight budget during the scan. Narrow datasets keep PyArrow's defaults, so throughput is unaffected.
+</Note>
 
 ### Iterator ingestion: for streaming or computed-on-the-fly data
 
-If your dataset doesn't fit in memory all at once (for example, when rows are computed on the fly (generating embeddings as you ingest), or pulled from a streaming source, materializing the full table before calling `add()` will cause you to run out of memory. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead. LanceDB consumes one batch at a time, so peak memory stays bounded by the batch size you yield.
+If your dataset doesn't fit in memory all at once — rows computed on the fly (generating embeddings as you ingest), or pulled from a streaming source — materializing the full table before calling `add()` will run you out of memory. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead. LanceDB consumes one batch at a time, so peak memory stays bounded by the batch size you yield.
 
 ```python Python icon="python"
 def stream():
@@ -57,7 +71,13 @@ def stream():
 table.add(stream())
 ```
 
-Streaming inputs don't auto-parallelize, so use decently large chunks of several thousand rows or more, rather than yielding single-row batches.
+Use decently large chunks of several thousand rows or more, rather than yielding single-row batches. Unlike a `Dataset`, a reader can't be counted ahead of time, so LanceDB can't auto-size parallelism for it — set `write_parallelism` yourself:
+
+```python Python icon="python"
+table.add(stream(), write_parallelism=4)
+```
+
+More parallelism means more write bandwidth, but each partition also becomes its own fragment, so over-parallelizing a small stream just fragments the table for no benefit. As a rule of thumb, don't budget more than one unit of parallelism per ~100K rows or ~1 GB of data — a 1,000-row stream needs `write_parallelism=1`, not more. `write_parallelism` is also a memory knob independent of that tradeoff: each partition buffers a batch in flight, so lower it if ingestion is using more memory than expected.
 
 ## Indexing
 

--- a/docs/performance.mdx
+++ b/docs/performance.mdx
@@ -52,19 +52,13 @@ table.add(ds.dataset("data/", format="parquet"), progress=True)
 71%|███████▏  | 710000/1000000 [00:12<00:05, 58.8kit/s, 42.3 MB/s | 8/8 workers]
 ```
 
-For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over a hand-built `pyarrow.RecordBatchReader`: a `Dataset` can be counted and rescanned, so LanceDB knows the row count upfront (better auto-parallelism) and can retry a failed write from the start — a reader can only be consumed once, so neither is possible. Reach for the iterator path below only when the data genuinely can't be backed by files, e.g. embeddings computed on the fly.
+For larger-than-memory data, prefer scanning a file-backed dataset (`ds.dataset(...)`) over a hand-built `pyarrow.RecordBatchReader`: a `Dataset` can be counted and rescanned, so LanceDB knows the row count upfront (better auto-parallelism) and can retry a failed write from the start — a reader can only be consumed once, so neither is possible. Reach for the iterator path below only when the data genuinely can't be backed by files, e.g. to apply custom data transformations as you ingest.
 
 For very large initial loads, create the table empty first; passing data directly to `create_table(name, data)` skips the auto-parallel path.
 
-<Note>
-**Wide rows and scan memory**
-
-Scanning a `pyarrow.dataset.Dataset` or `LanceDataset` for `add()` automatically bounds the scanner's batch size and read-ahead based on the schema's bytes-per-row, so wide-row datasets (large embedding columns, long text, many columns) stay near a ~1 GiB in-flight budget during the scan. Narrow datasets keep PyArrow's defaults, so throughput is unaffected.
-</Note>
-
 ### Iterator ingestion: for data you transform on the fly
 
-If each row needs work before it can be written — generating embeddings as you ingest, for example — the data doesn't exist as a file you can point `ds.dataset(...)` at. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead; LanceDB consumes one batch at a time as you produce them.
+If each row needs work before it can be written — applying a custom transformation as you ingest, for example — the data doesn't exist as a file you can point `ds.dataset(...)` at. The best practice is to pass an iterator of `pyarrow.RecordBatch` instead; LanceDB consumes one batch at a time as you produce them.
 
 ```python Python icon="python"
 def stream():


### PR DESCRIPTION
## Summary

Alternative to #312. That PR documented `write_parallelism` as primarily a memory-capping knob for wide rows and didn't mention the built-in progress bar or the tradeoffs of streaming a `RecordBatchReader` vs. a file-backed `Dataset`. This PR rewrites the Ingestion section of `docs/performance.mdx` instead:

- `write_parallelism`'s main benefit is write bandwidth: more partitions means more concurrent writes, up to the CPU core count.
- Documents `progress=True`, which shows a live tqdm bar with throughput (MB/s) and active worker count — currently undocumented anywhere — including a sample of what the output looks like.
- Clarifies that for larger-than-memory data, scanning a file-backed `Dataset` is preferable to a hand-built `RecordBatchReader`: only a `Dataset` can be counted and rescanned, which lets LanceDB auto-size parallelism and retry a failed write. A reader can only be consumed once, so neither is possible.
- Narrows iterator ingestion to its actual use case — data that needs per-row work before it can be written (e.g. applying a custom transformation as you ingest) — rather than "streaming" generally, and drops the memory framing (iterator ingestion isn't about memory).
- Adds a note under iterator ingestion for setting `write_parallelism` manually on large inputs, since LanceDB can't auto-size it without a countable/rescannable source, including a rule of thumb — budget one unit of parallelism per ~100K rows or ~1 GB, to avoid fragmenting small datasets.

## Test plan

- [ ] Read through the rendered Ingestion section for flow/accuracy
- [ ] Confirm no conflicting claims with #312 if both are being considered