### PR TITLE
Redirect Enterprise quickstart

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -552,6 +552,10 @@
       "destination": "/enterprise/benchmarks"
     },
     {
+      "source": "/enterprise/quickstart",
+      "destination": "/quickstart"
+    },
+    {
       "source": "/huggingface/overview",
       "destination": "/integrations/ai/huggingface"
     },


### PR DESCRIPTION
## Summary

The former Enterprise quickstart URL now redirects to the consolidated Quickstart guide.

## Problem

The Enterprise quickstart page was removed when its content was merged into the shared guide. Existing links and search results for `/enterprise/quickstart` therefore received a 404, including requests from AI chatbots that retained the old URL.

## Fix

Add a Mintlify manual redirect from `/enterprise/quickstart` to `/quickstart`. Visitors and crawlers are directed to the current guide instead of the removed page.

## Validation

- Confirmed `docs/docs.json` is valid JSON with `jq empty`.
- Confirmed the committed diff has no whitespace errors with `git diff --check HEAD^ HEAD`.
