### PR TITLE
docs: extract snippet so it doesn't drift like it did

### DIFF
--- a/docs/snippets/basic_usage.mdx
+++ b/docs/snippets/basic_usage.mdx
@@ -24,6 +24,8 @@ export const PyBasicImports = "import json\n\nimport lancedb\nimport pandas as p
 
 export const PyBasicOpenTable = "table = db.open_table(\"camelot\")\n";
 
+export const PyBasicSortPolars = "# Sort Polars DataFrame by power in descending order\nprint(r4.sort(\"power\", descending=True).limit(5))\n";
+
 export const PyBasicVectorSearch = "query_vector = [0.03, 0.85, 0.61, 0.90]\nresult = table.search(query_vector).limit(5).to_polars()\nprint(result)\n";
 
 export const PyBasicVectorSearchQ1 = "# Who are the characters similar to  \"wizard\"?\nquery_vector_1 = [0.03, 0.85, 0.61, 0.90]\nr1 = (\n    table.search(query_vector_1)\n    .limit(5)\n    .select([\"name\", \"role\", \"description\"])\n    .to_polars()\n)\nprint(r1)\n";

--- a/docs/tables/index.mdx
+++ b/docs/tables/index.mdx
@@ -21,6 +21,7 @@ import {
     PyBasicVectorSearchQ2,
     PyBasicVectorSearchQ3,
     PyBasicVectorSearchQ4,
+    PyBasicSortPolars,
     PyBasicDeleteRows,
     PyBasicAddData,
     PyBasicAddColumns,
@@ -534,10 +535,9 @@ You can also sort the results after converting them to a Polars DataFrame.
 In TypeScript/Rust, you can sort the
 returned array in application code.
 
-```python Python icon="python"
-# Sort Polars DataFrame by power in descending order
-print(r1.sort("power", descending=True).limit(5))
-```
+<CodeBlock filename="Python" language="Python">
+{PyBasicSortPolars}
+</CodeBlock>
 
 | name | role | description | power |
 | --- | --- | --- | --- |

--- a/tests/py/test_basic_usage.py
+++ b/tests/py/test_basic_usage.py
@@ -158,6 +158,14 @@ def test_basic_usage(db_path_factory):
     print(r4)
     # --8<-- [end:basic_vector_search_q4]
 
+    # --8<-- [start:basic_sort_polars]
+    # Sort Polars DataFrame by power in descending order
+    print(r4.sort("power", descending=True).limit(5))
+    # --8<-- [end:basic_sort_polars]
+    sorted_power = r4.sort("power", descending=True)["power"].to_list()
+    assert sorted_power == sorted(sorted_power, reverse=True)
+    assert sorted_power[0] == 4.0
+
     # --8<-- [start:basic_drop_columns]
     table.drop_columns(["power"])
     # --8<-- [end:basic_drop_columns]


### PR DESCRIPTION
This `r1.sort` should be `r4.sort`. This was able to drift because we hadn't pulled it out as a snippet. Here it is pulled out and tested.