### PR TITLE
chore: freeze docs automation during migration

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,8 +1,11 @@
 name: Sync OpenAPI Spec
 
+# The weekly schedule and the auto-merge step are suspended for the duration of
+# the documentation migration, during which no automation may write to `main`
+# unattended. Run this manually when the spec needs syncing; it opens a pull
+# request for a human to merge. Restore both when the migration completes.
+
 on:
-  schedule:
-    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -43,21 +46,3 @@ jobs:
             Syncs `docs/api-reference/rest/openapi.yml` from `lance-format/lance-namespace` (`docs/src/rest.yaml`).
           branch: "chore/sync-openapi"
           delete-branch: true
-
-      - name: Wait for checks and merge
-        if: steps.cpr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ secrets.DOCS_BOT_TOKEN }}
-        run: |
-          set -euo pipefail
-          pr="${{ steps.cpr.outputs.pull-request-number }}"
-          # Give the pull_request workflow a moment to register checks before watching.
-          for i in $(seq 1 10); do
-            if gh pr checks "$pr" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then break; fi
-            sleep 15
-          done
-          gh pr checks "$pr" -R "$GITHUB_REPOSITORY" --watch --fail-fast --interval 30
-          # --admin bypasses the "require status check" base-branch policy on the
-          # immediate merge. Safe here: checks are already confirmed green above, and
-          # the bot token (admin) only ever merges this one bot-generated sync PR.
-          gh pr merge "$pr" -R "$GITHUB_REPOSITORY" --squash --delete-branch --admin


### PR DESCRIPTION
First step of the documentation migration: stop automation from writing to `main` unattended while the tree is being restructured.

`sync-openapi.yml` ran weekly on cron and then self-merged with `gh pr merge --squash --admin`, bypassing the base-branch status-check policy. That conflicts with the anchor pass, the Geneva removal, and the page moves, all of which need a tree that does not move underneath them.

This removes the `schedule` trigger and the auto-merge step. `workflow_dispatch` stays as the manual path — it opens a pull request for a human to merge. The job's `if:` guard is untouched so restoring the schedule later is a pure re-add of the `schedule` block.

Two companion actions are manual and happen outside this PR:

- Mintlify is repointed from `main` to the `deploy-freeze` branch (pinned at 03ad18f), so the site keeps serving while deploys pause.
- The `mintlify[bot]` catch-up writer is stopped.

Human documentation pull requests continue to merge to `main` as normal — they queue and ship together at the migration's first cutover.